### PR TITLE
build fix

### DIFF
--- a/SXR/Extensions/platformsdk_support/build.gradle
+++ b/SXR/Extensions/platformsdk_support/build.gradle
@@ -20,7 +20,7 @@ android {
             if (rootProject.hasProperty("SXRSDK_ABI_FILTER")) {
                 abiFilters rootProject.property("SXRSDK_ABI_FILTER")
             } else {
-                abiFilters "armeabi-v7a", "arm64-v8a"
+                abiFilters "armeabi-v7a"
             }
         }
         externalNativeBuild {


### PR DESCRIPTION
the platformsdk doesn't have a 64bit lib, so the build for Extensions
currently fails.  this excludes the 64bit abi for the platformsdk.

SXR-DCO-Signed-off-by: Tom Flynn
tom.flynn@samsung.com