### PR TITLE
Cv lib integration

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryAnchor.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryAnchor.java
@@ -1,0 +1,103 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.samsungxr.mixedreality.CVLibrary;
+
+//import com.google.ar.core.Anchor;
+import com.samsungxr.SXRContext;
+import com.samsungxr.mixedreality.SXRAnchor;
+import com.samsungxr.mixedreality.SXRTrackingState;
+import com.samsungxr.mixedreality.arcore.ARCorePose;
+
+/**
+ * Represents a ARCore anchor in the scene.
+ *
+ */
+public class CVLibraryAnchor extends SXRAnchor {
+    //private Anchor mAnchor;
+    private ARCorePose mPose;
+
+    protected CVLibraryAnchor(SXRContext gvrContext) {
+        super(gvrContext);
+        mPose = new ARCorePose();
+    }
+
+    /**
+     * Sets ARCore anchor
+     *
+     *   ARCore Anchor instance
+     */
+    protected void setAnchorAR() {
+
+        //this.mAnchor = anchor;
+        return;
+    }
+
+    /**
+     * Set the anchor tracking state
+     *
+     * @param state
+     */
+    protected void setTrackingState(SXRTrackingState state) { mTrackingState = state; }
+
+    /**
+     * @return ARCore Anchor instance
+     */
+//    protected Anchor getAnchorAR() {
+//
+//        //return this.mAnchor;
+//        return null;
+//    }
+
+    @Override
+    public SXRTrackingState getTrackingState() {
+        return mTrackingState;
+    }
+
+    @Override
+    public String getCloudAnchorId() {
+
+        //return mAnchor.getCloudAnchorId();
+        return null;
+    }
+
+    /**
+     * Update the anchor based on arcore best knowledge of the world
+     *
+     * @param viewmtx
+     * @param gvrmatrix
+     * @param scale
+     */
+    protected void update(float[] viewmtx, float[] gvrmatrix, float scale) {
+        // Updates only when the plane is in the scene
+        if (getParent() == null || !isEnabled()) {
+            return;
+        }
+
+        convertFromARtoVRSpace(viewmtx, gvrmatrix, scale);
+    }
+
+    /**
+     * Converts from ARCore world space to SXRf's world space.
+     *
+     * @param arViewMatrix Phone's camera view matrix.
+     * @param vrCamMatrix SXRf Camera matrix.
+     * @param scale Scale from AR to SXRf world.
+     */
+    protected void convertFromARtoVRSpace(float[] arViewMatrix, float[] vrCamMatrix, float scale) {
+//        mPose.update(mAnchor.getPose(), arViewMatrix, vrCamMatrix, scale);
+//        getTransform().setModelMatrix(mPose.getPoseMatrix());
+    }
+}

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryAugmentedImage.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryAugmentedImage.java
@@ -1,0 +1,79 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.samsungxr.mixedreality.CVLibrary;
+
+//import com.google.ar.core.AugmentedImage;
+import com.samsungxr.mixedreality.SXRAugmentedImage;
+import com.samsungxr.mixedreality.SXRTrackingState;
+
+/**
+ * Represents an ARCore Augmented Image
+ */
+public class CVLibraryAugmentedImage extends SXRAugmentedImage {
+    //private AugmentedImage mAugmentedImage;
+
+    protected CVLibraryAugmentedImage() {
+        //mAugmentedImage = augmentedImage;
+        mTrackingState = SXRTrackingState.PAUSED;
+    }
+
+    /**
+     * @return Returns the estimated width
+     */
+    @Override
+    public float getExtentX() {
+        //return mAugmentedImage.getExtentX();
+        return 1.0f;
+    }
+
+    /**
+     * @return Returns the estimated height
+     */
+    @Override
+    public float getExtentZ() {
+
+        return 1.0f;
+        //return mAugmentedImage.getExtentZ();
+    }
+
+    /**
+     * @return The augmented image center pose
+     */
+    @Override
+    public float[] getCenterPose() {
+        float[] centerPose = new float[16];
+        //mAugmentedImage.getCenterPose().toMatrix(centerPose, 0);
+        return centerPose;
+    }
+
+    /**
+     *
+     * @return The tracking state
+     */
+    @Override
+    public SXRTrackingState getTrackingState() {
+        return mTrackingState;
+    }
+
+    /**
+     * Set the augmented image tracking state
+     *
+     * @param state
+     */
+    protected void setTrackingState(SXRTrackingState state) {
+        mTrackingState = state;
+    }
+}

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryHelper.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryHelper.java
@@ -1,0 +1,318 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.samsungxr.mixedreality.CVLibrary;
+
+//import com.google.ar.core.Anchor;
+//import com.google.ar.core.AugmentedImage;
+//import com.google.ar.core.HitResult;
+//import com.google.ar.core.LightEstimate;
+//import com.google.ar.core.Plane;
+//import com.google.ar.core.Trackable;
+//import com.google.ar.core.TrackingState;
+import android.util.Log;
+
+import com.samsungxr.SXRContext;
+import com.samsungxr.SXRNode;
+import com.samsungxr.SXRScene;
+import com.samsungxr.mixedreality.IAnchorEventsListener;
+import com.samsungxr.mixedreality.IAugmentedImageEventsListener;
+import com.samsungxr.mixedreality.IPlaneEventsListener;
+import com.samsungxr.mixedreality.SXRAnchor;
+import com.samsungxr.mixedreality.SXRAugmentedImage;
+import com.samsungxr.mixedreality.SXRHitResult;
+import com.samsungxr.mixedreality.SXRLightEstimate;
+import com.samsungxr.mixedreality.SXRPlane;
+import com.samsungxr.mixedreality.SXRTrackingState;
+import com.samsungxr.mixedreality.CVLibrary.CVLibraryAnchor;
+import com.samsungxr.mixedreality.CVLibrary.CVLibraryAugmentedImage;
+import com.samsungxr.mixedreality.CVLibrary.CVLibraryLightEstimate;
+import com.samsungxr.mixedreality.CVLibrary.CVLibraryPlane;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CVLibraryHelper {
+    private SXRContext mGvrContext;
+    private SXRScene mGvrScene;
+    CVLibraryPlane arCorePlane;
+    boolean init = false;
+
+//    private Map<Plane, ARCorePlane> mArPlanes;
+//    private Map<AugmentedImage, ARCoreAugmentedImage> mArAugmentedImages;
+    private List<CVLibraryAnchor> mArAnchors;
+
+    private ArrayList<IPlaneEventsListener> planeEventsListeners = new ArrayList<>();
+    private ArrayList<IAnchorEventsListener> anchorEventsListeners = new ArrayList<>();
+    private ArrayList<IAugmentedImageEventsListener> augmentedImageEventsListeners = new ArrayList<>();
+
+    public CVLibraryHelper(SXRContext gvrContext, SXRScene gvrScene) {
+        mGvrContext = gvrContext;
+        mGvrScene = gvrScene;
+//        mArPlanes = new HashMap<>();
+//        mArAugmentedImages = new HashMap<>();
+        mArAnchors = new ArrayList<>();
+    }
+
+    public void updatePlanes(float[] arViewMatrix,
+                             float[] vrCamMatrix, float scale) {
+//
+//        for (Plane plane: allPlanes) {
+//            if (plane.getTrackingState() != TrackingState.TRACKING
+//                    || mArPlanes.containsKey(plane)) {
+//                continue;
+//            }
+//
+        if (!init){
+            arCorePlane = createPlane();
+            notifyPlaneDetectionListeners(arCorePlane);
+            Log.i("TestingDemo", "Inside updatePlanes");
+            init = true;
+
+        }
+//        }
+//
+//        for (Plane plane: mArPlanes.keySet()) {
+//            arCorePlane = mArPlanes.get(plane);
+//
+//            if (plane.getTrackingState() == TrackingState.TRACKING &&
+//                    arCorePlane.getTrackingState() != SXRTrackingState.TRACKING) {
+//                arCorePlane.setTrackingState(SXRTrackingState.TRACKING);
+//                notifyPlaneStateChangeListeners(arCorePlane, SXRTrackingState.TRACKING);
+//            }
+//            else if (plane.getTrackingState() == TrackingState.PAUSED &&
+//                    arCorePlane.getTrackingState() != SXRTrackingState.PAUSED) {
+//                arCorePlane.setTrackingState(SXRTrackingState.PAUSED);
+//                notifyPlaneStateChangeListeners(arCorePlane, SXRTrackingState.PAUSED);
+//            }
+//            else if (plane.getTrackingState() == TrackingState.STOPPED &&
+//                    arCorePlane.getTrackingState() != SXRTrackingState.STOPPED) {
+//                arCorePlane.setTrackingState(SXRTrackingState.STOPPED);
+//                notifyPlaneStateChangeListeners(arCorePlane, SXRTrackingState.STOPPED);
+//            }
+//
+//            if (plane.getSubsumedBy() != null && arCorePlane.getParentPlane() == null) {
+//                arCorePlane.setParentPlane(mArPlanes.get(plane.getSubsumedBy()));
+//                notifyMergedPlane(arCorePlane, arCorePlane.getParentPlane());
+//            }
+//
+//            arCorePlane.update(arViewMatrix, vrCamMatrix, scale);
+//        }
+    }
+
+    public void updateAugmentedImages(){
+//        ARCoreAugmentedImage arCoreAugmentedImage;
+//
+//        for (AugmentedImage augmentedImage: allAugmentedImages) {
+//            if (augmentedImage.getTrackingState() != TrackingState.TRACKING
+//                || mArAugmentedImages.containsKey(augmentedImage)) {
+//                continue;
+//            }
+//
+//            arCoreAugmentedImage = createAugmentedImage(augmentedImage);
+//            notifyAugmentedImageDetectionListeners(arCoreAugmentedImage);
+//
+//            mArAugmentedImages.put(augmentedImage, arCoreAugmentedImage);
+//        }
+//
+//        for (AugmentedImage augmentedImage: mArAugmentedImages.keySet()) {
+//            arCoreAugmentedImage = mArAugmentedImages.get(augmentedImage);
+//
+//            if (augmentedImage.getTrackingState() == TrackingState.TRACKING &&
+//                    arCoreAugmentedImage.getTrackingState() != SXRTrackingState.TRACKING) {
+//                arCoreAugmentedImage.setTrackingState(SXRTrackingState.TRACKING);
+//                notifyAugmentedImageStateChangeListeners(arCoreAugmentedImage, SXRTrackingState.TRACKING);
+//            }
+//            else if (augmentedImage.getTrackingState() == TrackingState.PAUSED &&
+//                    arCoreAugmentedImage.getTrackingState() != SXRTrackingState.PAUSED) {
+//                arCoreAugmentedImage.setTrackingState(SXRTrackingState.PAUSED);
+//                notifyAugmentedImageStateChangeListeners(arCoreAugmentedImage, SXRTrackingState.PAUSED);
+//            }
+//            else if (augmentedImage.getTrackingState() == TrackingState.STOPPED &&
+//                    arCoreAugmentedImage.getTrackingState() != SXRTrackingState.STOPPED) {
+//                arCoreAugmentedImage.setTrackingState(SXRTrackingState.STOPPED);
+//                notifyAugmentedImageStateChangeListeners(arCoreAugmentedImage, SXRTrackingState.STOPPED);
+//            }
+//        }
+    }
+
+    public void updateAnchors(float[] arViewMatrix, float[] vrCamMatrix, float scale) {
+
+//        for (ARCoreAnchor anchor: mArAnchors) {
+//            Anchor arAnchor = anchor.getAnchorAR();
+//
+//            if (arAnchor.getTrackingState() == TrackingState.TRACKING &&
+//                    anchor.getTrackingState() != SXRTrackingState.TRACKING) {
+//                anchor.setTrackingState(SXRTrackingState.TRACKING);
+//                notifyAnchorStateChangeListeners(anchor, SXRTrackingState.TRACKING);
+//            }
+//            else if (arAnchor.getTrackingState() == TrackingState.PAUSED &&
+//                    anchor.getTrackingState() != SXRTrackingState.PAUSED) {
+//                anchor.setTrackingState(SXRTrackingState.PAUSED);
+//                notifyAnchorStateChangeListeners(anchor, SXRTrackingState.PAUSED);
+//            }
+//            else if (arAnchor.getTrackingState() == TrackingState.STOPPED &&
+//                    anchor.getTrackingState() != SXRTrackingState.STOPPED) {
+//                anchor.setTrackingState(SXRTrackingState.STOPPED);
+//                notifyAnchorStateChangeListeners(anchor, SXRTrackingState.STOPPED);
+//            }
+//
+//            anchor.update(arViewMatrix, vrCamMatrix, scale);
+//        }
+        return;
+    }
+
+    public ArrayList<SXRPlane> getAllPlanes() {
+        ArrayList<SXRPlane> allPlanes = new ArrayList<>();
+        allPlanes.add(arCorePlane);
+//        for (Plane plane: mArPlanes.keySet()) {
+//            allPlanes.add(mArPlanes.get(plane));
+//        }
+
+        return allPlanes;
+    }
+
+    public ArrayList<SXRAugmentedImage> getAllAugmentedImages() {
+//        ArrayList<SXRAugmentedImage> allAugmentedImages = new ArrayList<>();
+//
+//        for (AugmentedImage augmentedImage: mArAugmentedImages.keySet()) {
+//            allAugmentedImages.add(mArAugmentedImages.get(augmentedImage));
+//        }
+//
+//        return allAugmentedImages;
+        return null;
+    }
+
+    public CVLibraryPlane createPlane() {
+        CVLibraryPlane arCorePlane = new CVLibraryPlane(mGvrContext);
+        //mArPlanes.put(plane, arCorePlane);
+        return arCorePlane;
+    }
+
+    public CVLibraryAugmentedImage createAugmentedImage() {
+        CVLibraryAugmentedImage arCoreAugmentedImage = new CVLibraryAugmentedImage();
+        return arCoreAugmentedImage;
+    }
+
+    public SXRAnchor createAnchor(SXRNode sceneObject) {
+        CVLibraryAnchor arCoreAnchor = new CVLibraryAnchor(mGvrContext);
+        arCoreAnchor.setAnchorAR();
+        mArAnchors.add(arCoreAnchor);
+
+        if (sceneObject != null) {
+            arCoreAnchor.attachNode(sceneObject);
+        }
+
+        return arCoreAnchor;
+    }
+
+    public void updateAnchorPose(CVLibraryAnchor anchor) {
+//        if (anchor.getAnchorAR() != null) {
+//            anchor.getAnchorAR().detach();
+//        }
+//        anchor.setAnchorAR(arAnchor);
+    }
+
+    public void removeAnchor(CVLibraryAnchor anchor) {
+        //anchor.getAnchorAR().detach();
+        mArAnchors.remove(anchor);
+        mGvrScene.removeNode(anchor);
+    }
+
+    public SXRHitResult hitTest() {
+//        for (HitResult hit : hitResult) {
+//            // Check if any plane was hit, and if it was hit inside the plane polygon
+//            Trackable trackable = hit.getTrackable();
+//            // Creates an anchor if a plane or an oriented point was hit.
+//            if ((trackable instanceof Plane
+//                    && ((Plane) trackable).isPoseInPolygon(hit.getHitPose()))
+//                    && ((Plane) trackable).getSubsumedBy() == null) {
+//                SXRHitResult gvrHitResult = new SXRHitResult();
+//                float[] hitPose = new float[16];
+//
+//                hit.getHitPose().toMatrix(hitPose, 0);
+//                gvrHitResult.setPose(hitPose);
+//                gvrHitResult.setDistance(hit.getDistance());
+//                gvrHitResult.setPlane(mArPlanes.get(trackable));
+//
+//                return gvrHitResult;
+//            }
+//        }
+
+        Log.i("TestingDemo", "Inside the CVLibraryHelper hitTest. created basic hit");
+
+        SXRHitResult gvrHitResult = new SXRHitResult();
+        float[] hitPose = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+        gvrHitResult.setPose(hitPose);
+        return gvrHitResult;
+    }
+
+    public SXRLightEstimate getLightEstimate() {
+        CVLibraryLightEstimate arCoreLightEstimate = new CVLibraryLightEstimate();
+
+        return arCoreLightEstimate;
+    }
+
+    public void registerPlaneListener(IPlaneEventsListener listener) {
+        planeEventsListeners.add(listener);
+    }
+
+    public void registerAnchorListener(IAnchorEventsListener listener) {
+        anchorEventsListeners.add(listener);
+    }
+
+    public void registerAugmentedImageListener(IAugmentedImageEventsListener listener) {
+        augmentedImageEventsListeners.add(listener);
+    }
+
+    private void notifyPlaneDetectionListeners(SXRPlane plane) {
+        for (IPlaneEventsListener listener: planeEventsListeners) {
+            listener.onPlaneDetection(plane);
+        }
+    }
+
+    private void notifyPlaneStateChangeListeners(SXRPlane plane, SXRTrackingState trackingState) {
+        for (IPlaneEventsListener listener: planeEventsListeners) {
+            listener.onPlaneStateChange(plane, trackingState);
+        }
+    }
+
+    private void notifyMergedPlane(SXRPlane childPlane, SXRPlane parentPlane) {
+        for (IPlaneEventsListener listener: planeEventsListeners) {
+            listener.onPlaneMerging(childPlane, parentPlane);
+        }
+    }
+
+    private void notifyAnchorStateChangeListeners(SXRAnchor anchor, SXRTrackingState trackingState) {
+        for (IAnchorEventsListener listener: anchorEventsListeners) {
+            listener.onAnchorStateChange(anchor, trackingState);
+        }
+    }
+
+    private void notifyAugmentedImageDetectionListeners(SXRAugmentedImage image) {
+        for (IAugmentedImageEventsListener listener: augmentedImageEventsListeners) {
+            listener.onAugmentedImageDetection(image);
+        }
+    }
+
+    private void notifyAugmentedImageStateChangeListeners(SXRAugmentedImage image, SXRTrackingState trackingState) {
+        for (IAugmentedImageEventsListener listener: augmentedImageEventsListeners) {
+            listener.onAugmentedImageStateChange(image, trackingState);
+        }
+    }
+}

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryLightEstimate.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryLightEstimate.java
@@ -1,0 +1,49 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.samsungxr.mixedreality.CVLibrary;
+
+import com.samsungxr.mixedreality.SXRLightEstimate;
+
+
+public class CVLibraryLightEstimate extends SXRLightEstimate {
+    /**
+     * Set the pixel intensity of light
+     *
+     * @param intensity
+     */
+    protected void setPixelIntensity(float intensity) {
+        mPixelIntensity = intensity;
+    }
+
+    /**
+     * Set the state of light estimate
+     *
+     * @param state
+     */
+    protected void setState(SXRLightEstimateState state) {
+        mState = state;
+    }
+
+    @Override
+    public float getPixelIntensity() {
+        return 1.0f;
+    }
+
+    @Override
+    public SXRLightEstimateState getLightEstimateState() {
+        return mState;
+    }
+}

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryPlane.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryPlane.java
@@ -1,0 +1,143 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.samsungxr.mixedreality.CVLibrary;
+
+//import com.google.ar.core.Plane;
+import com.samsungxr.SXRContext;
+import com.samsungxr.mixedreality.SXRPlane;
+import com.samsungxr.mixedreality.SXRTrackingState;
+
+import java.nio.FloatBuffer;
+
+
+class CVLibraryPlane extends SXRPlane {
+    //private Plane mARPlane;
+    private CVLibraryPose mPose;
+
+    protected CVLibraryPlane(SXRContext gvrContext) {
+        super(gvrContext);
+        mPose = new CVLibraryPose();
+        //mARPlane = plane;
+        mType = Type.HORIZONTAL_UPWARD_FACING;
+
+//        if (mARPlane.getType() == Plane.Type.HORIZONTAL_DOWNWARD_FACING) {
+//            mType = Type.HORIZONTAL_DOWNWARD_FACING;
+//        }
+//        else if (mARPlane.getType() == Plane.Type.HORIZONTAL_UPWARD_FACING) {
+//            mType = Type.HORIZONTAL_UPWARD_FACING;
+//        }
+//        else {
+//            mType = Type.VERTICAL;
+//        }
+    }
+
+    /**
+     * Set the plane tracking state
+     *
+     * @param state
+     */
+    protected void setTrackingState(SXRTrackingState state) {
+        mTrackingState = state;
+    }
+
+    /**
+     * Set the parent plane (only when plane is merged)
+     *
+     * @param plane
+     */
+    protected void setParentPlane(SXRPlane plane) {
+        mParentPlane = plane;
+    }
+
+    @Override
+    public SXRTrackingState getTrackingState() {
+        return mTrackingState;
+    }
+
+    @Override
+    public float[] getCenterPose() {
+        //float[] centerPose = new float[16];
+        //mARPlane.getCenterPose().toMatrix(centerPose, 0);
+        float[] centerPose = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+        return centerPose;
+    }
+
+    @Override
+    public Type getPlaneType() {
+        return mType;
+    }
+
+    @Override
+    public float getWidth() {
+
+        //return mARPlane.getExtentX();
+        return 0.1f;
+    }
+
+    @Override
+    public float getHeight() {
+
+        //return mARPlane.getExtentZ();
+        return 0.1f;
+    }
+
+    @Override
+    public FloatBuffer getPolygon() {
+
+        //return mARPlane.getPolygon();
+        return null;
+    }
+
+    @Override
+    public SXRPlane getParentPlane() {
+        return mParentPlane;
+    }
+
+    /**
+     * Update the plane based on arcore best knowledge of the world
+     *
+     * @param viewmtx
+     * @param gvrmatrix
+     * @param scale
+     */
+    protected void update(float[] viewmtx, float[] gvrmatrix, float scale) {
+//        // Updates only when the plane is in the scene
+//        if (getParent() == null || !isEnabled()) {
+//            return;
+//        }
+//
+//        convertFromARtoVRSpace(viewmtx, gvrmatrix, scale);
+//
+//        if (mNode != null) {
+//            mNode.getTransform().setScale(mARPlane.getExtentX() * 0.95f,
+//                    mARPlane.getExtentZ() * 0.95f, 1.0f);
+//        }
+        return;
+    }
+    
+    /**
+     * Converts from ARCore world space to SXRf's world space.
+     *
+     * @param arViewMatrix Phone's camera view matrix
+     * @param vrCamMatrix SXRf Camera matrix
+     * @param scale Scale from AR to SXRf world
+     */
+    private void convertFromARtoVRSpace(float[] arViewMatrix, float[] vrCamMatrix, float scale) {
+        //mPose.update(mARPlane.getCenterPose(), arViewMatrix, vrCamMatrix, scale);
+        //getTransform().setModelMatrix(mPose.getPoseMatrix());
+        return;
+    }
+}

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryPose.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryPose.java
@@ -1,0 +1,68 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.samsungxr.mixedreality.CVLibrary;
+
+import android.opengl.Matrix;
+
+//import com.google.ar.core.Pose;
+
+/**
+ * Represents a ARCore pose in the scene.
+ */
+public class CVLibraryPose {
+    // Aux matrix to convert from AR world space to AR cam space.
+    private static float[] mModelViewMatrix = new float[16];
+    // Represents a AR Pose at SXRf's world space
+    private float[] mPoseMatrix = new float[16];
+
+    /**
+     * Returns the ARCore Pose matrix in SXRf's world space
+     *
+     * @return The pose matrix in SXRf's world space.
+     */
+    public float[] getPoseMatrix() {
+        return mPoseMatrix;
+    }
+
+    /**
+     * Converts from ARCore world space to SXRf's world space
+     *
+     * pose AR Core Pose instance
+     * @param arViewMatrix Phone's camera view matrix
+     * @param vrCamMatrix SXRf Camera matrix
+     * @param scale Scale from AR to SXRf world
+     */
+    public void update(float[] arViewMatrix, float[] vrCamMatrix, float scale) {
+//        pose.toMatrix(mPoseMatrix, 0);
+//        ar2gvr(arViewMatrix, vrCamMatrix, scale);
+    }
+
+    /**
+     * Converts from AR world space to SXRf world space.
+     */
+//    private void ar2gvr(float[] ARViewMatrix, float[] SXRCamMatrix, float scale) {
+//        // From AR world space to AR camera space.
+//        Matrix.multiplyMM(mModelViewMatrix, 0, ARViewMatrix, 0, mPoseMatrix, 0);
+//        // From AR Camera space to SXRf world space
+//        Matrix.multiplyMM(mPoseMatrix, 0, SXRCamMatrix, 0, mModelViewMatrix, 0);
+//
+//        // Real world scale
+//        Matrix.scaleM(mPoseMatrix, 0, scale, scale, scale);
+//        mPoseMatrix[12] = mPoseMatrix[12] * scale;
+//        mPoseMatrix[13] = mPoseMatrix[13] * scale;
+//        mPoseMatrix[14] = mPoseMatrix[14] * scale;
+//    }
+}

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibrarySession.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibrarySession.java
@@ -1,0 +1,413 @@
+/* Copyright 2015 Samsung Electronics Co., LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.samsungxr.mixedreality.CVLibrary;
+
+import android.app.Activity;
+import android.app.Service;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.graphics.Bitmap;
+import android.opengl.Matrix;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.view.Surface;
+import android.app.Activity;
+
+//import com.google.ar.core.Anchor;
+//import com.google.ar.core.ArCoreApk;
+//import com.google.ar.core.AugmentedImage;
+//import com.google.ar.core.AugmentedImageDatabase;
+//import com.google.ar.core.Camera;
+//import com.google.ar.core.Config;
+//import com.google.ar.core.Frame;
+//import com.google.ar.core.HitResult;
+//import com.google.ar.core.Plane;
+//import com.google.ar.core.Pose;
+//import com.google.ar.core.Session;
+//import com.google.ar.core.TrackingState;
+//import com.google.ar.core.exceptions.CameraNotAvailableException;
+//import com.google.ar.core.exceptions.UnavailableApkTooOldException;
+//import com.google.ar.core.exceptions.UnavailableArcoreNotInstalledException;
+//import com.google.ar.core.exceptions.UnavailableSdkTooOldException;
+//import com.google.ar.core.exceptions.UnavailableUserDeclinedInstallationException;
+
+import com.samsungxr.SXRCameraRig;
+import com.samsungxr.SXRContext;
+import com.samsungxr.SXRDrawFrameListener;
+import com.samsungxr.SXRExternalTexture;
+import com.samsungxr.SXRMaterial;
+import com.samsungxr.SXRMeshCollider;
+import com.samsungxr.SXRPicker;
+import com.samsungxr.SXRRenderData;
+import com.samsungxr.SXRScene;
+import com.samsungxr.SXRNode;
+import com.samsungxr.SXRTexture;
+import com.samsungxr.mixedreality.SXRAnchor;
+import com.samsungxr.mixedreality.SXRAugmentedImage;
+import com.samsungxr.mixedreality.SXRHitResult;
+import com.samsungxr.mixedreality.SXRLightEstimate;
+import com.samsungxr.mixedreality.SXRPlane;
+import com.samsungxr.mixedreality.IAnchorEventsListener;
+import com.samsungxr.mixedreality.IAugmentedImageEventsListener;
+import com.samsungxr.mixedreality.ICloudAnchorListener;
+import com.samsungxr.mixedreality.IPlaneEventsListener;
+import com.samsungxr.mixedreality.MRCommon;
+import com.samsungxr.mixedreality.CameraPermissionHelper;
+import com.samsungxr.mixedreality.CVLibrary.CVLibraryHelper;
+import com.samsungxr.utility.Log;
+import org.joml.Math;
+import org.joml.Matrix4f;
+import org.joml.Quaternionf;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.Math.toDegrees;
+
+
+public class CVLibrarySession extends MRCommon{
+
+
+    private Context context;
+
+    private static float PASSTHROUGH_DISTANCE = 100.0f;
+    private static float AR2VR_SCALE = 100;
+    private static Activity sActivity;
+
+    private boolean mInstallRequested;
+
+    private SXRScene mVRScene;
+    private SXRNode mARPassThroughObject;
+    private ARCoreHandler mARCoreHandler;
+    private boolean mEnableCloudAnchor;
+
+
+    /* From AR to SXR space matrices */
+    private float[] mSXRModelMatrix = new float[16];
+    private float[] mARViewMatrix = new float[16];
+    private float[] mSXRCamMatrix = new float[16];
+    private float[] mModelViewMatrix = new float[16];
+
+    private Vector3f mDisplayGeometry;
+
+    private CVLibraryHelper mCVLibraryHelper;
+
+    //private final HashMap<Anchor, ICloudAnchorListener> pendingAnchors = new HashMap<>();
+
+    public CVLibrarySession(SXRContext gvrContext, boolean enableCloudAnchor) {
+        super(gvrContext);
+        mVRScene = gvrContext.getMainScene();
+        mCVLibraryHelper = new CVLibraryHelper(gvrContext, mVRScene);
+        mEnableCloudAnchor = enableCloudAnchor;
+
+    }
+
+
+    @Override
+    protected void onResume() {
+
+        Log.d(TAG, "onResumeAR");
+//
+//        if (mSession == null) {
+//
+//            if (!checkARCoreAndCamera()) {
+//                return;
+//            }
+//
+//            // Create default config and check if supported.
+//            mConfig = new Config(mSession);
+////            if (mEnableCloudAnchor) {
+////                mConfig.setCloudAnchorMode(Config.CloudAnchorMode.ENABLED);
+////            }
+//            mConfig.setUpdateMode(Config.UpdateMode.LATEST_CAMERA_IMAGE);
+//            if (!mSession.isSupported(mConfig)) {
+//                showSnackbarMessage("This device does not support AR", true);
+//            }
+//            mSession.configure(mConfig);
+//        }
+//
+//        showLoadingMessage();
+//
+//        try {
+//            mSession.resume();
+//        } catch (CameraNotAvailableException e) {
+//            e.printStackTrace();
+//        }
+//
+        mGvrContext.runOnGlThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    onInitARCoreSession(mGvrContext);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onPause() {
+        Log.d(TAG, "onPause");
+//
+//        if (mSession != null) {
+//            mSession.pause();
+//        }
+    }
+
+    private void onInitARCoreSession(SXRContext gvrContext)  {
+//        SXRTexture passThroughTexture = new SXRExternalTexture(gvrContext);
+//
+//        mSession.setCameraTextureName(passThroughTexture.getId());
+
+        // FIXME: detect VR screen aspect ratio. Using empirical 16:9 aspect ratio
+        /* Try other aspect ration whether virtual objects looks jumping ou sliding
+        during camera's rotation.
+         */
+//        mSession.setDisplayGeometry(Surface.ROTATION_90 , 160, 90);
+//
+//        mLastARFrame = mSession.update();
+//        mDisplayGeometry = configDisplayGeometry(mLastARFrame.getCamera());
+//
+//        mSession.setDisplayGeometry(Surface.ROTATION_90 ,
+//                (int)mDisplayGeometry.x, (int)mDisplayGeometry.y);
+//
+//        /* To render texture from phone's camera */
+//        mARPassThroughObject = new SXRNode(gvrContext, mDisplayGeometry.x, mDisplayGeometry.y,
+//                passThroughTexture, SXRMaterial.SXRShaderType.OES.ID);
+
+//        mARPassThroughObject.getRenderData().setRenderingOrder(SXRRenderData.SXRRenderingOrder.BACKGROUND);
+//        mARPassThroughObject.getRenderData().setDepthTest(false);
+//        mARPassThroughObject.getTransform().setPosition(0, 0, mDisplayGeometry.z);
+//        mARPassThroughObject.attachComponent(new SXRMeshCollider(gvrContext, true));
+//
+//        mVRScene.addNode(mARPassThroughObject);
+
+        /* AR main loop */
+        mARCoreHandler = new ARCoreHandler();
+        gvrContext.registerDrawFrameListener(mARCoreHandler);
+
+        //mSXRCamMatrix = mVRScene.getMainCameraRig().getHeadTransform().getModelMatrix();
+
+        //updateAR2SXRMatrices(mLastARFrame.getCamera(), mVRScene.getMainCameraRig());
+    }
+
+
+    public class ARCoreHandler implements SXRDrawFrameListener {
+        @Override
+        public void onDrawFrame(float v) {
+
+//            try {
+//                arFrame = mSession.update();
+//            } catch (CameraNotAvailableException e) {
+//                e.printStackTrace();
+//                mGvrContext.unregisterDrawFrameListener(this);
+//                return;
+//            }
+
+//            Camera arCamera = arFrame.getCamera();
+//
+//            if (arFrame.getTimestamp() == mLastARFrame.getTimestamp()) {
+//                // FIXME: ARCore works at 30fps.
+//                return;
+//            }
+//
+//            if (arCamera.getTrackingState() != TrackingState.TRACKING) {
+//                // Put passthrough object in from of current VR cam at paused states.
+//                updateAR2SXRMatrices(arCamera, mVRScene.getMainCameraRig());
+//                updatePassThroughObject(mARPassThroughObject);
+//
+//                return;
+//            }
+
+            // Update current AR cam's view matrix.
+            //arCamera.getViewMatrix(mARViewMatrix, 0);
+
+            // Update passthrough object with last VR cam matrix
+           // updatePassThroughObject(mARPassThroughObject);
+
+            mCVLibraryHelper.updatePlanes(mARViewMatrix, mSXRCamMatrix, AR2VR_SCALE);
+
+            //mCVLibraryHelper.updateAugmentedImages(arFrame.getUpdatedTrackables(AugmentedImage.class));
+
+            mCVLibraryHelper.updateAnchors(mARViewMatrix, mSXRCamMatrix, AR2VR_SCALE);
+
+//            updateCloudAnchors(arFrame.getUpdatedAnchors());
+
+            //mLastARFrame = arFrame;
+
+            // Update current VR cam's matrix to next update of passtrhough and virtual objects.
+            // AR/30fps vs VR/60fps
+//            mSXRCamMatrix = mVRScene.getMainCameraRig().getHeadTransform().getModelMatrix();
+        }
+    }
+
+    @Override
+    protected SXRNode onGetPassThroughObject() {
+        return mARPassThroughObject;
+    }
+
+    @Override
+    protected void onRegisterPlaneListener(IPlaneEventsListener listener) {
+        mCVLibraryHelper.registerPlaneListener(listener);
+    }
+
+    @Override
+    protected void onRegisterAnchorListener(IAnchorEventsListener listener) {
+        mCVLibraryHelper.registerAnchorListener(listener);
+    }
+
+    @Override
+    protected void onRegisterAugmentedImageListener(IAugmentedImageEventsListener listener) {
+        mCVLibraryHelper.registerAugmentedImageListener(listener);
+    }
+
+    @Override
+    protected ArrayList<SXRPlane> onGetAllPlanes() {
+        return mCVLibraryHelper.getAllPlanes();
+    }
+
+    @Override
+    protected SXRAnchor onCreateAnchor(float[] pose, SXRNode sceneObject) {
+//        float[] translation = new float[3];
+//        float[] rotation = new float[4];
+//
+//        convertMatrixPoseToVector(pose, translation, rotation);
+//
+//        Anchor anchor = mSession.createAnchor(new Pose(translation, rotation));
+        return mCVLibraryHelper.createAnchor(sceneObject);
+    }
+
+    @Override
+    protected void onUpdateAnchorPose(SXRAnchor anchor, float[] pose) {
+//        float[] translation = new float[3];
+//        float[] rotation = new float[4];
+//
+//        convertMatrixPoseToVector(pose, translation, rotation);
+//
+//        Anchor arAnchor = mSession.createAnchor(new Pose(translation, rotation));
+        mCVLibraryHelper.updateAnchorPose((CVLibraryAnchor)anchor);
+    }
+
+    @Override
+    protected void onRemoveAnchor(SXRAnchor anchor) {
+//        mCVLibraryHelper.removeAnchor((ARCoreAnchor)anchor);
+        return;
+    }
+
+    /**
+     * This method hosts an anchor. The {@code listener} will be invoked when the results are
+     * available.
+     */
+    @Override
+    synchronized protected void onHostAnchor(SXRAnchor anchor, ICloudAnchorListener listener) {
+//        Anchor newAnchor = mSession.hostCloudAnchor(((ARCoreAnchor)anchor).getAnchorAR());
+//        pendingAnchors.put(newAnchor, listener);
+        return;
+    }
+
+    /**
+     * This method resolves an anchor. The {@code listener} will be invoked when the results are
+     * available.
+     */
+    synchronized protected void onResolveCloudAnchor(String anchorId, ICloudAnchorListener listener) {
+//        Anchor newAnchor = mSession.resolveCloudAnchor(anchorId);
+//        pendingAnchors.put(newAnchor, listener);
+        return;
+    }
+
+    /** Should be called with the updated anchors available after a {@link Session#update()} call. */
+//    synchronized void updateCloudAnchors(Collection<Anchor> updatedAnchors) {
+//        for (Anchor anchor : updatedAnchors) {
+//            if (pendingAnchors.containsKey(anchor)) {
+//                Anchor.CloudAnchorState cloudState = anchor.getCloudAnchorState();
+////                if (isReturnableState(cloudState)) {
+////                    ICloudAnchorListener listener = pendingAnchors.remove(anchor);
+////                    SXRAnchor newAnchor = mCVLibraryHelper.createAnchor(anchor, null);
+////                    listener.onTaskComplete(newAnchor);
+////                }
+//            }
+//        }
+//    }
+
+    /** Used to clear any currently registered listeners, so they wont be called again. */
+//    synchronized void clearListeners() {
+//        pendingAnchors.clear();
+//    }
+
+//    private static boolean isReturnableState(Anchor.CloudAnchorState cloudState) {
+//        switch (cloudState) {
+//            case NONE:
+//            case TASK_IN_PROGRESS:
+//                return false;
+//            default:
+//                return true;
+//        }
+//    }
+
+    @Override
+    protected void onSetEnableCloudAnchor(boolean enableCloudAnchor) {
+        mEnableCloudAnchor = enableCloudAnchor;
+    }
+
+    @Override
+    protected SXRHitResult onHitTest(SXRNode sceneObj, SXRPicker.SXRPickedObject collision) {
+//        if (sceneObj != mARPassThroughObject)
+//            return null;
+//
+//        Vector2f tapPosition = convertToDisplayGeometrySpace(collision.getHitLocation());
+//        List<HitResult> hitResult = arFrame.hitTest(tapPosition.x, tapPosition.y);
+        return mCVLibraryHelper.hitTest();
+    }
+
+    @Override
+    protected SXRLightEstimate onGetLightEstimate() {
+        return mCVLibraryHelper.getLightEstimate();
+    }
+
+    @Override
+    protected void onSetAugmentedImage(Bitmap image) {
+//        ArrayList<Bitmap> imagesList = new ArrayList<>();
+//        imagesList.add(image);
+//        onSetAugmentedImages(imagesList);
+    }
+
+    @Override
+    protected void onSetAugmentedImages(ArrayList<Bitmap> imagesList) {
+//        AugmentedImageDatabase augmentedImageDatabase = new AugmentedImageDatabase(mSession);
+//        for (Bitmap image: imagesList) {
+//            augmentedImageDatabase.addImage("image_name", image);
+//        }
+//
+//        mConfig.setAugmentedImageDatabase(augmentedImageDatabase);
+//        mSession.configure(mConfig);
+    }
+
+    @Override
+    protected ArrayList<SXRAugmentedImage> onGetAllAugmentedImages() {
+//        return mCVLibraryHelper.getAllAugmentedImages();
+        return null;
+    }
+}

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
@@ -25,6 +25,7 @@ import com.samsungxr.SXRScene;
 import com.samsungxr.SXRNode;
 import com.samsungxr.IActivityEvents;
 import com.samsungxr.mixedreality.arcore.ARCoreSession;
+import com.samsungxr.mixedreality.CVLibrary.CVLibrarySession;
 
 import java.util.ArrayList;
 
@@ -33,7 +34,7 @@ import java.util.ArrayList;
  */
 public class SXRMixedReality extends SXRBehavior implements IMRCommon {
     private final IActivityEvents mActivityEventsHandler;
-    private final MRCommon mSession;
+    private MRCommon mSession = null;
     private SessionState mState;
 
     /**
@@ -41,8 +42,8 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
      *
      * @param gvrContext
      */
-    public SXRMixedReality(final SXRContext gvrContext) {
-        this(gvrContext, false, null);
+    public SXRMixedReality(final SXRContext gvrContext, int platform) {
+        this(gvrContext, false, null, platform);
     }
 
     /**
@@ -51,8 +52,8 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
      * @param gvrContext
      * @param enableCloudAnchor
      */
-    public SXRMixedReality(final SXRContext gvrContext, boolean enableCloudAnchor) {
-        this(gvrContext, enableCloudAnchor, null);
+    public SXRMixedReality(final SXRContext gvrContext, boolean enableCloudAnchor, int platform) {
+        this(gvrContext, enableCloudAnchor, null, platform);
     }
 
     /**
@@ -61,8 +62,8 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
      * @param gvrContext
      * @param scene
      */
-    public SXRMixedReality(final SXRContext gvrContext, SXRScene scene) {
-        this(gvrContext, false, scene);
+    public SXRMixedReality(final SXRContext gvrContext, SXRScene scene, int platform) {
+        this(gvrContext, false, scene, platform);
     }
 
     /**
@@ -73,7 +74,7 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
      * @param enableCloudAnchor
      * @param scene
      */
-    public SXRMixedReality(SXRContext gvrContext, boolean enableCloudAnchor, SXRScene scene) {
+    public SXRMixedReality(SXRContext gvrContext, boolean enableCloudAnchor, SXRScene scene, int platform) {
         super(gvrContext, 0);
 
 
@@ -82,10 +83,31 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
         }
 
         mActivityEventsHandler = new ActivityEventsHandler();
-        mSession = new ARCoreSession(gvrContext, enableCloudAnchor);
+        selectARPlatform(platform, enableCloudAnchor);
         mState = SessionState.ON_PAUSE;
 
         scene.getMainCameraRig().getOwnerObject().attachComponent(this);
+    }
+
+    public SXRMixedReality(SXRScene scene, int platform, boolean enableCloudAnchor) {
+        super(scene.getSXRContext(), 0);
+        mActivityEventsHandler = new ActivityEventsHandler();
+        selectARPlatform(platform, enableCloudAnchor);
+        mState = SessionState.ON_PAUSE;
+
+        scene.getMainCameraRig().getOwnerObject().attachComponent(this);
+    }
+
+    public void selectARPlatform(int platform, boolean enableCloudAnchor)
+    {
+        if (platform != 0)
+        {
+            mSession = new CVLibrarySession(getSXRContext(), enableCloudAnchor);
+        }
+        else
+        {
+            mSession = new ARCoreSession(getSXRContext(), enableCloudAnchor);
+        }
     }
 
     @Override


### PR DESCRIPTION
Added CV library session for used in Mixed Reality extensions instead of ARCore dependence. The CV Library session will work in a headset with external camera and place a plane on the marker with an object on the center of that plane.