### PR TITLE
Support vertex color shader in jassimp

### DIFF
--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
@@ -1148,7 +1148,7 @@ class  SXRJassimpAdapter
             AiMesh aiMesh)
     {
         EnumSet<SXRImportSettings> settings = assetRequest.getImportSettings();
-        SXRMaterial gvrMaterial = createMaterial(aiMaterial, settings);
+        SXRMaterial gvrMaterial = createMaterial(aiMaterial, settings, aiMesh.hasVertexColors());
         AiColor diffuseColor = aiMaterial.getDiffuseColor(sWrapperProvider);
         float opacity = diffuseColor.getAlpha();
 
@@ -1208,7 +1208,7 @@ class  SXRJassimpAdapter
         return gvrMaterial;
     }
 
-    private SXRMaterial createMaterial(AiMaterial material, EnumSet<SXRImportSettings> settings)
+    private SXRMaterial createMaterial(AiMaterial material, EnumSet<SXRImportSettings> settings, boolean hasVertexColors)
     {
         boolean layered = false;
         SXRShaderId shaderType;
@@ -1265,10 +1265,18 @@ class  SXRJassimpAdapter
             {
                 shaderType = SXRMaterial.SXRShaderType.Phong.ID;
             }
-            if (layered)
+            if (hasVertexColors)
+            {
+                shaderType = SXRMaterial.SXRShaderType.Color.ID;
+            }
+            else if (layered)
             {
                 shaderType = SXRMaterial.SXRShaderType.PhongLayered.ID;
             }
+        }
+        else if (hasVertexColors)
+        {
+            shaderType = SXRMaterial.SXRShaderType.Color.ID;
         }
         else
         {

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/shaders/SXRTextureShader.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/shaders/SXRTextureShader.java
@@ -14,20 +14,18 @@
  */
 package com.samsungxr.shaders;
 
-import java.util.HashMap;
-import java.util.List;
+import android.content.Context;
 
+import com.samsungxr.IRenderable;
+import com.samsungxr.R;
 import com.samsungxr.SXRContext;
 import com.samsungxr.SXRRenderData;
 import com.samsungxr.SXRScene;
 import com.samsungxr.SXRShaderData;
 import com.samsungxr.SXRShaderTemplate;
-import com.samsungxr.IRenderable;
 import com.samsungxr.utility.TextFile;
 
-import android.content.Context;
-
-import com.samsungxr.R;
+import java.util.HashMap;
 
 /**
  * Manages a set of variants on vertex and fragment shaders from the same source

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/shaders/SXRVertexColorShader.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/shaders/SXRVertexColorShader.java
@@ -2,23 +2,71 @@ package com.samsungxr.shaders;
 
 import android.content.Context;
 
-import com.samsungxr.SXRContext;
-import com.samsungxr.SXRShaderTemplate;
+import com.samsungxr.IRenderable;
 import com.samsungxr.R;
+import com.samsungxr.SXRContext;
+import com.samsungxr.SXRScene;
+import com.samsungxr.SXRShaderData;
+import com.samsungxr.SXRShaderTemplate;
 import com.samsungxr.utility.TextFile;
+
+import java.util.HashMap;
 
 public class SXRVertexColorShader extends SXRShaderTemplate
 {
     private static String fragTemplate = null;
     private static String vtxTemplate = null;
+    private static String surfaceShader = null;
+    private static String addLight = null;
+    private static String vtxShader = null;
+    private static String normalShader = null;
+    private static String skinShader = null;
+    private static String morphShader = null;
 
     public SXRVertexColorShader(SXRContext gvrcontext)
     {
-        super("float line_width", "", "float3 a_position float4 a_color", GLSLESVersion.VULKAN);
-        Context context = gvrcontext.getContext();
-        fragTemplate = TextFile.readTextFile(context, R.raw.vcolor_fragment);
-        vtxTemplate = TextFile.readTextFile(context, R.raw.vcolor_vertex);
+        super("float4 ambient_color; float4 diffuse_color; float4 specular_color; float4 emissive_color; float specular_exponent; float line_width",
+              "",
+              "float3 a_position; float4 a_color, float3 a_normal", GLSLESVersion.VULKAN);
+        if (fragTemplate == null) {
+            Context context = gvrcontext.getContext();
+            fragTemplate = TextFile.readTextFile(context, R.raw.fragment_template);
+            vtxTemplate = TextFile.readTextFile(context, R.raw.vcolor_vertex);
+            vtxShader = TextFile.readTextFile(context, R.raw.pos_norm_tex);
+            surfaceShader = TextFile.readTextFile(context, R.raw.vcolor_surface);
+            normalShader = TextFile.readTextFile(context, R.raw.normalmap);
+            skinShader = TextFile.readTextFile(context, R.raw.vertexskinning);
+            morphShader = TextFile.readTextFile(context, R.raw.vertexmorph);
+            addLight = TextFile.readTextFile(context, R.raw.addlight);
+        }
         setSegment("FragmentTemplate", fragTemplate);
         setSegment("VertexTemplate", vtxTemplate);
+        setSegment("FragmentSurface", surfaceShader);
+        setSegment("FragmentAddLight", addLight);
+        setSegment("VertexSkinShader", skinShader);
+        setSegment("VertexMorphShader", morphShader);
+        setSegment("VertexShader", vtxShader);
+        setSegment("VertexNormalShader", normalShader);
+        mHasVariants = true;
+        mUsesLights = true;
+    }
+    public HashMap<String, Integer> getRenderDefines(IRenderable renderable, SXRScene scene)
+    {
+        HashMap<String, Integer> defines = super.getRenderDefines(renderable, scene);
+        if (!defines.containsKey("LIGHTSOURCES") || (defines.get("LIGHTSOURCES") != 1))
+        {
+            defines.put("a_normal", 0);
+        }
+        return defines;
+    }
+
+
+    protected void setMaterialDefaults(SXRShaderData material)
+    {
+        material.setVec4("ambient_color", 0, 0, 0, 1);
+        material.setVec4("diffuse_color", 1, 1, 1, 1);
+        material.setVec4("specular_color", 0, 0, 0, 1);
+        material.setVec4("emissive_color", 0, 0, 0, 1);
+        material.setFloat("specular_exponent", 0.0f);
     }
 }

--- a/SXR/SDK/sxrsdk/src/main/res/raw/vcolor_surface.fsh
+++ b/SXR/SDK/sxrsdk/src/main/res/raw/vcolor_surface.fsh
@@ -1,0 +1,26 @@
+@MATERIAL_UNIFORMS
+
+layout(location = 3) in vec4 vertex_color;
+
+struct Surface
+{
+   vec3 viewspaceNormal;
+   vec4 ambient;
+   vec4 diffuse;
+   vec4 specular;
+   vec4 emission;
+};
+
+Surface @ShaderName()
+{
+	vec4 diffuse = diffuse_color * vertex_color;
+	vec4 emission = emissive_color;
+	vec4 specular = specular_color;
+	vec4 ambient = ambient_color;
+	vec3 viewspaceNormal;
+
+    diffuse.xyz *= diffuse.w;
+	viewspaceNormal = viewspace_normal;
+	return Surface(viewspaceNormal, ambient, diffuse, specular, emission);
+
+}

--- a/SXR/SDK/sxrsdk/src/main/res/raw/vcolor_vertex.vsh
+++ b/SXR/SDK/sxrsdk/src/main/res/raw/vcolor_vertex.vsh
@@ -1,31 +1,112 @@
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_ARB_shading_language_420pack : enable
 
+
 #ifdef HAS_MULTIVIEW
 #extension GL_OVR_multiview2 : enable
 layout(num_views = 2) in;
 #endif
-
-precision mediump float;
-
-layout ( location = 0 ) in vec3 a_position;
-layout ( location = 1 ) in vec4 a_color;
+precision highp float;
+precision lowp int;
 
 @MATRIX_UNIFORMS
 
-layout ( location = 0 ) out vec4 v_color;
+@MATERIAL_UNIFORMS
 
-void main()
-{
-    vec4 pos = vec4(a_position, 1);
-#ifdef HAS_MULTIVIEW
-    bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
-    mat4 mvp = u_mvp_[gl_ViewID_OVR];
-    if(!render_mask)
-        mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
-    gl_Position = mvp  * pos;
-#else
-  	gl_Position = u_mvp * pos;
+layout(location = 0) in vec3 a_position;
+
+#ifdef HAS_a_texcoord
+layout(location = 1) in vec2 a_texcoord;
 #endif
-    v_color = a_color;
-}
+
+#if defined(HAS_a_normal) && defined(HAS_LIGHTSOURCES)
+layout(location = 2) in vec3 a_normal;
+#endif
+
+
+#ifdef HAS_VertexSkinShader
+#ifdef HAS_a_bone_weights
+@BONES_UNIFORMS
+
+layout(location = 6) in vec4 a_bone_weights;
+layout(location = 7) in ivec4 a_bone_indices;
+#endif
+#endif
+
+#ifdef HAS_VertexNormalShader
+#ifdef HAS_a_tangent
+layout(location = 8) in vec3 a_tangent;
+layout(location = 9) in vec3 a_bitangent;
+layout(location = 7) out mat3 tangent_matrix;
+#endif
+#endif
+
+layout(location = 0) out vec3 view_direction;
+layout(location = 1) out vec3 viewspace_position;
+layout(location = 2) out vec3 viewspace_normal;
+layout(location = 3) out vec4 vertex_color;
+
+
+#ifdef HAS_blendshapeTexture
+layout (set = 0, binding = 17) uniform sampler2D blendshapeTexture;
+#endif
+
+struct Vertex
+{
+	vec4 local_position;
+	vec4 local_normal;
+	vec3 local_tangent;
+	vec3 local_bitangent;
+	vec3 viewspace_position;
+	vec3 viewspace_normal;
+	vec3 view_direction;
+};
+
+#ifdef HAS_LIGHTSOURCES
+	@LIGHTSOURCES
+#endif
+
+void main() {
+	Vertex vertex;
+
+	vertex.local_position = vec4(a_position.xyz, 1.0);
+#ifdef HAS_a_normal
+    vertex.local_normal = vec4(normalize(a_normal), 0.0);
+#endif
+#ifdef HAS_a_tangent
+    vertex.local_tangent = a_tangent;
+    vertex.local_bitangent = a_bitangent;
+#endif
+#ifdef HAS_VertexMorphShader
+@VertexMorphShader
+#endif
+
+#ifdef HAS_VertexSkinShader
+@VertexSkinShader
+#endif
+
+#ifdef HAS_VertexNormalShader
+@VertexNormalShader
+#endif
+
+@VertexShader
+
+#ifdef HAS_LIGHTSOURCES
+     LightVertex(vertex);
+ #endif
+ #ifdef HAS_TEXCOORDS
+ @TEXCOORDS
+ #endif
+     viewspace_position = vertex.viewspace_position;
+     viewspace_normal = vertex.viewspace_normal;
+     view_direction = vertex.view_direction;
+ #ifdef HAS_MULTIVIEW
+     bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
+     mat4 mvp = u_mvp_[gl_ViewID_OVR];
+     if (!render_mask)
+         mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
+     gl_Position = mvp  * vertex.local_position;
+ #else
+ 	gl_Position = u_mvp * vertex.local_position;
+ #endif
+ }

--- a/SXR/SDK/sxrsdk/src/main/res/raw/vertex_template.vsh
+++ b/SXR/SDK/sxrsdk/src/main/res/raw/vertex_template.vsh
@@ -100,21 +100,21 @@ void main() {
 @VertexShader
 
 #ifdef HAS_LIGHTSOURCES
-    LightVertex(vertex);
-#endif
-#ifdef HAS_TEXCOORDS
-@TEXCOORDS
-#endif
-    viewspace_position = vertex.viewspace_position;
-    viewspace_normal = vertex.viewspace_normal;
-    view_direction = vertex.view_direction;
-#ifdef HAS_MULTIVIEW
-    bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
-    mat4 mvp = u_mvp_[gl_ViewID_OVR];
-    if (!render_mask)
-        mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
-    gl_Position = mvp  * vertex.local_position;
-#else
-	gl_Position = u_mvp * vertex.local_position;
-#endif	
-}
+     LightVertex(vertex);
+ #endif
+ #ifdef HAS_TEXCOORDS
+ @TEXCOORDS
+ #endif
+     viewspace_position = vertex.viewspace_position;
+     viewspace_normal = vertex.viewspace_normal;
+     view_direction = vertex.view_direction;
+ #ifdef HAS_MULTIVIEW
+     bool render_mask = (u_render_mask & (gl_ViewID_OVR + uint(1))) > uint(0) ? true : false;
+     mat4 mvp = u_mvp_[gl_ViewID_OVR];
+     if (!render_mask)
+         mvp = mat4(0.0);  //  if render_mask is not set for particular eye, dont render that object
+     gl_Position = mvp  * vertex.local_position;
+ #else
+ 	gl_Position = u_mvp * vertex.local_position;
+ #endif
+ }


### PR DESCRIPTION
If vertex colors are found in a mesh, Jassimp will now use GVRVertexColorShader instead of GVRPhongShader. The vertex color shader has been rewritten to allow lighting if normals are also present in the mesh.

GearVRF DCO signed off by: Nola Donato nola.donato@samsung.com

This PR has not been tested yet. It is for Mitch to review.

Original PR: https://github.com/Samsung/GearVRf/pull/2006
SXR-DCO-1.0-Signed-off-by: Mihail Marinov m.marinov@samsung.com
