### PR TITLE
auto detect the drop-in device for the mixed reality extension

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
@@ -136,6 +136,11 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
      */
     public void selectARPlatform(int platform, boolean enableCloudAnchor)
     {
+        String prop = System.getProperty("debug.samsungxr.hmt");
+        if(prop != null && prop.equals("AR-DROP-IN2") {
+            platform = 1;
+        }
+
         if (platform != 0)
         {
             mSession = new CVLibrarySession(getSXRContext(), enableCloudAnchor);

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
@@ -137,7 +137,7 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
     public void selectARPlatform(int platform, boolean enableCloudAnchor)
     {
         String prop = System.getProperty("debug.samsungxr.hmt");
-        if(prop != null && prop.equals("AR-DROP-IN2") {
+        if(prop != null && prop.equals("AR-DROP-IN2")) {
             platform = 1;
         }
 

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
@@ -24,6 +24,7 @@ import com.samsungxr.SXRPicker;
 import com.samsungxr.SXRScene;
 import com.samsungxr.SXRNode;
 import com.samsungxr.IActivityEvents;
+import com.samsungxr.SystemPropertyUtil;
 import com.samsungxr.mixedreality.arcore.ARCoreSession;
 import com.samsungxr.mixedreality.CVLibrary.CVLibrarySession;
 
@@ -136,7 +137,7 @@ public class SXRMixedReality extends SXRBehavior implements IMRCommon {
      */
     public void selectARPlatform(int platform, boolean enableCloudAnchor)
     {
-        String prop = System.getProperty("debug.samsungxr.hmt");
+        String prop = SystemPropertyUtil.getSystemPropertyString("debug.samsungxr.hmt");
         if(prop != null && prop.equals("AR-DROP-IN2")) {
             platform = 1;
         }


### PR DESCRIPTION
auto detect the drop-in device for the mixed reality extension

SXR-DCO-Signed-off-by: Tom Flynn
tom.flynn@samsung.com