### PR TITLE
Fix SXRTextViewNode text small bug when width equals height

### DIFF
--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRTextViewNode.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRTextViewNode.java
@@ -139,7 +139,7 @@ public class SXRTextViewNode extends SXRNode {
         if (canvasWidth > canvasHeight && canvasWidth > MAX_IMAGE_SIZE) {
             canvasWidth = MAX_IMAGE_SIZE;
             canvasHeight = (int)(MAX_IMAGE_SIZE/factor);
-        } else if (canvasHeight > canvasWidth && canvasHeight > MAX_IMAGE_SIZE) {
+        } else if (canvasHeight >= canvasWidth && canvasHeight > MAX_IMAGE_SIZE) {
             canvasWidth = (int)(MAX_IMAGE_SIZE*factor);
             canvasHeight = MAX_IMAGE_SIZE;
         }


### PR DESCRIPTION
I found a bug when creating a new `SXRTextViewNode` with width value that equals height value (e.g: `20.0f`). The current behaviour make the text incredibly small because the `canvasWidth` and `canvasHeight` is left unmodified and in turn made the `LayoutParams` initialized with too large parameters. 

This is because the following condition didn't account for the case where `canvasWidth == canvasHeight`.

This PR add the above edge case to process too.

SXR DCO signed off by: Luong Vu luongvm183@gmail.com