### PR TITLE
GVRDepthShader to SXRDepthShader

### DIFF
--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -432,7 +432,7 @@ namespace sxr
     /**
      * Generate shadow maps for all the lights that cast shadows.
      * The scene is rendered from the viewpoint of the light using a
-     * special depth shader (GVRDepthShader) to create the shadow map.
+     * special depth shader (SXRDepthShader) to create the shadow map.
      * @see Renderer::renderShadowMap Light::makeShadowMap
      */
     void GLRenderer::makeShadowMaps(Scene* scene, jobject javaSceneObject, ShaderManager* shader_manager)
@@ -500,7 +500,7 @@ namespace sxr
                 ShaderData *bbox_material = new GLMaterial("", "");
                 RenderPass *pass = Renderer::getInstance()->createRenderPass();
                 GLShader *bboxShader = static_cast<GLShader *>(rstate.shader_manager
-                        ->findShader("GVRBoundingBoxShader"));
+                        ->findShader("SXRBoundingBoxShader"));
                 pass->set_shader(bboxShader->getProgramId(), false);
                 pass->set_material(bbox_material);
                 bounding_box_render_data->set_mesh(bounding_box_mesh);
@@ -568,7 +568,7 @@ namespace sxr
         if (rstate.is_shadow && curr_material)
         {
             const char* depthShaderName = render_data->owner_object()->getComponent(Skin::getComponentType()) ?
-                                          "GVRDepthShader$a_bone_weights$a_bone_indices" : "GVRDepthShader";
+                                          "SXRDepthShader$a_bone_weights$a_bone_indices" : "SXRDepthShader";
             shader = rstate.shader_manager->findShader(depthShaderName);
 
             if (shader == nullptr)
@@ -623,7 +623,7 @@ namespace sxr
         {
             LOGE("Error detected in Renderer::renderRenderData; name : %s, error : %s",
                  render_data->owner_object()->name().c_str(), error.c_str());
-            shader = rstate.shader_manager->findShader("GVRErrorShader");
+            shader = rstate.shader_manager->findShader("SXRErrorShader");
             shader->useShader(rstate.is_multiview);
         }
         if ((drawMode == GL_LINE_STRIP) ||


### PR DESCRIPTION
GVRDepthShader to SXRDepthShader.  now the sxr-shadows app no longer
complains about a missing GVRDepthShader.  it still only renders in the
corner, but it at least isn't complaining about the depth shader now.

SXR-DCO-Signed-off-by: Tom Flynn
tom.flynn@samsung.com