### PR TITLE
fix suspicious things about rendertargets in monoscopic

### DIFF
--- a/SXR/SDK/backend_monoscopic/src/main/java/com/samsungxr/MonoscopicViewManager.java
+++ b/SXR/SDK/backend_monoscopic/src/main/java/com/samsungxr/MonoscopicViewManager.java
@@ -406,11 +406,10 @@ class MonoscopicViewManager extends SXRViewManager implements MonoscopicRotation
         mMainScene.getMainCameraRig().updateRotation();
         SXRRenderTarget renderTarget = getRenderTarget();
         renderTarget.cullFromCamera(mMainScene, mMainScene.getMainCameraRig().getCenterCamera(), mRenderBundle.getShaderManager());
-        captureCenterEye(renderTarget, false);
         renderTarget.render(mMainScene, mMainScene
                         .getMainCameraRig().getCenterCamera(), mRenderBundle.getShaderManager(), mRenderBundle.getPostEffectRenderTextureA(),
                 mRenderBundle.getPostEffectRenderTextureB());
-        captureLeftEye(renderTarget, false);
+        captureCenterEye(renderTarget, false);
 
     }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_texture.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_texture.h
@@ -79,7 +79,7 @@ protected:
     int layer_index_;
     int viewport_[4];
     void initialize();
-    void generateRenderTextureNoMultiSampling(int jdepth_format,GLenum depth_format, int width, int height);
+    void generateRenderTextureNoMultiSampling(int jdepth_format,GLenum depth_format, int width, int height, int jcolor_format);
     void generateRenderTextureEXT(int sample_count,int jdepth_format,GLenum depth_format, int width, int height);
     void generateRenderTexture(int sample_count, int jdepth_format, GLenum depth_format, int width,
                                int height, int jcolor_format);


### PR DESCRIPTION
fix suspicious things about rendertargets in monoscopic.  mainly that
the creation routine for non-multisample rendertargets was significantly
different that multisampled ones.

this doesn't fix sxr-shadows, simplephysics, rendertotexture, or
blurfilter.  but they are all related to rendertargets in monoscopic.

SXR-DCO-Signed-off-by: Tom Flynn
tom.flynn@samsung.com