### PR TITLE
fix fbo and viewport issues with monoscopic backend

### DIFF
--- a/SXR/SDK/backend_monoscopic/src/main/java/com/samsungxr/MonoscopicViewManager.java
+++ b/SXR/SDK/backend_monoscopic/src/main/java/com/samsungxr/MonoscopicViewManager.java
@@ -345,7 +345,8 @@ class MonoscopicViewManager extends SXRViewManager implements MonoscopicRotation
                 mRenderBundle.addRenderTarget(mRenderTarget[2], SXRViewManager.EYE.LEFT, 2);
             }
             else{
-                mRenderTarget[0] = new SXRRenderTarget(mApplication.getSXRContext());
+                mRenderTarget[0] = new SXRRenderTarget(mApplication.getSXRContext(), mViewportWidth,
+                                                        mViewportHeight);
             }
         }
 

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderTarget.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderTarget.java
@@ -54,7 +54,14 @@ public class SXRRenderTarget extends SXRBehavior
     }
     public SXRRenderTarget(SXRContext gvrContext)
     {
-        super(gvrContext,NativeRenderTarget.defaultCtr(gvrContext.getMainScene().getNative()));
+        super(gvrContext,NativeRenderTarget.defaultCtor(gvrContext.getMainScene().getNative()));
+        mScene = gvrContext.getMainScene();
+    }
+
+    public SXRRenderTarget(SXRContext gvrContext, int defaultViewportW, int defaultViewportH)
+    {
+        super(gvrContext,NativeRenderTarget.ctorViewport(gvrContext.getMainScene().getNative(),
+                defaultViewportW, defaultViewportH));
         mScene = gvrContext.getMainScene();
     }
 
@@ -144,7 +151,8 @@ public class SXRRenderTarget extends SXRBehavior
 
 class NativeRenderTarget
 {
-    static native long defaultCtr(long scene);
+    static native long defaultCtor(long scene);
+    static native long ctorViewport(long scene, int defaultViewportW, int defaultViewportH);
     static native long getComponentType();
     static native void setMainScene(long rendertarget, long scene);
     static native void beginRendering(long rendertarget, long camera);

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.cpp
@@ -55,6 +55,9 @@ namespace sxr
     RenderTarget* GLRenderer::createRenderTarget(Scene* scene) {
         return new GLRenderTarget(scene);
     }
+    RenderTarget* GLRenderer::createRenderTarget(Scene* scene, int defaultViewportW, int defaultViewportH) {
+        return new GLRenderTarget(scene, defaultViewportW, defaultViewportH);
+    }
     RenderTarget* GLRenderer::createRenderTarget(RenderTexture* renderTexture, bool isMultiview){
         return new GLRenderTarget(renderTexture, isMultiview);
     }

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.h
@@ -88,6 +88,7 @@ public:
     virtual Image* createImage(int type, int format);
     virtual Texture* createTexture(int target = GL_TEXTURE_2D);
     virtual RenderTarget* createRenderTarget(Scene*) ;
+    virtual RenderTarget* createRenderTarget(Scene*, int defaultViewportW, int defaultViewportH) ;
     virtual RenderTarget* createRenderTarget(RenderTexture*, bool);
     virtual RenderTarget* createRenderTarget(RenderTexture*, const RenderTarget*);
     virtual RenderTexture* createRenderTexture(const RenderTextureInfo&);

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/renderer.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/renderer.h
@@ -160,6 +160,7 @@ public:
 
     virtual void renderRenderData(RenderState& rstate, RenderData* render_data);
     virtual RenderTarget* createRenderTarget(Scene*) = 0;
+    virtual RenderTarget* createRenderTarget(Scene*, int defaultViewportW, int defaultViewportH) = 0;
     virtual RenderTarget* createRenderTarget(RenderTexture*, bool) = 0;
     virtual RenderTarget* createRenderTarget(RenderTexture*, const RenderTarget*) = 0;
 

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.cpp
@@ -70,6 +70,10 @@ RenderTarget* VulkanRenderer::createRenderTarget(Scene* scene) {
     return new VkRenderTarget(scene);
 }
 
+RenderTarget* VulkanRenderer::createRenderTarget(Scene* scene, int defaultViewportW, int defaultViewPortH) {
+    return new VkRenderTarget(scene);
+}
+
 RenderTarget* VulkanRenderer::createRenderTarget(RenderTexture* renderTexture, bool isMultiview)
 {
     return new VkRenderTarget(renderTexture, isMultiview);

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.h
@@ -114,6 +114,7 @@ public:
     virtual UniformBlock* createUniformBlock(const char* desc, int binding, const char* name, int maxelems);
     Image* createImage(int type, int format);
     virtual RenderTarget* createRenderTarget(Scene*);
+    virtual RenderTarget* createRenderTarget(Scene*, int defaultViewportW, int defaultViewportH);
     virtual RenderTarget* createRenderTarget(RenderTexture*, bool);
     virtual RenderTarget* createRenderTarget(RenderTexture*, const RenderTarget*);
     virtual Texture* createTexture(int target = GL_TEXTURE_2D);

--- a/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_target.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_target.h
@@ -16,12 +16,17 @@ class Renderer;
 class GLRenderTarget : public RenderTarget
 {
 public:
-    explicit GLRenderTarget(RenderTexture* renderTexture, bool is_multiview): RenderTarget(renderTexture, is_multiview){
+    explicit GLRenderTarget(RenderTexture* renderTexture, bool is_multiview):
+            RenderTarget(renderTexture, is_multiview){}
 
-    }
-    explicit GLRenderTarget(Scene* scene): RenderTarget(scene){
-    }
-    explicit GLRenderTarget(RenderTexture* renderTexture, const RenderTarget* source): RenderTarget(renderTexture, source){}
+    explicit GLRenderTarget(Scene* scene): RenderTarget(scene){}
+
+    explicit GLRenderTarget(Scene* scene, int defaultViewportW, int defaultViewportH):
+            RenderTarget(scene, defaultViewportW, defaultViewportH){}
+
+    explicit GLRenderTarget(RenderTexture* renderTexture, const RenderTarget* source):
+            RenderTarget(renderTexture, source){}
+
     GLRenderTarget(){}
     virtual void beginRendering(Renderer *renderer);
 };

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.cpp
@@ -47,8 +47,12 @@ RenderTarget::RenderTarget(RenderTexture* tex, bool is_multiview)
     }
 }
 void RenderTarget::beginRendering(Renderer *renderer) {
-    if(mRenderTexture == nullptr)
+    if(mRenderTexture == nullptr) {
+        //if there is no render texture as in case of monoscopic backend, we are using default fbo
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glViewport(0,0,mRenderState.viewportWidth,mRenderState.viewportHeight);
         return;
+    }
 
     mRenderTexture->useStencil(renderer->useStencilBuffer());
     mRenderState.viewportWidth = mRenderTexture->width();
@@ -76,6 +80,18 @@ RenderTarget::RenderTarget(Scene* scene)
     mRenderState.scene = scene;
 
 }
+
+RenderTarget::RenderTarget(Scene* scene, int defaultViewportW, int defaultViewportH)
+        : Component(RenderTarget::getComponentType()), mNextRenderTarget(nullptr), mRenderTexture(nullptr),mRenderDataVector(std::make_shared< std::vector<RenderData*>>()){
+    mRenderState.is_shadow = false;
+    mRenderState.shadow_map = nullptr;
+    mRenderState.material_override = NULL;
+    mRenderState.is_multiview = false;
+    mRenderState.scene = scene;
+    mRenderState.viewportWidth = defaultViewportW;
+    mRenderState.viewportHeight = defaultViewportH;
+}
+
 RenderTarget::RenderTarget(RenderTexture* tex, const RenderTarget* source)
         : Component(RenderTarget::getComponentType()),mNextRenderTarget(nullptr),
           mRenderTexture(tex), mRenderDataVector(source->mRenderDataVector)

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.h
@@ -43,6 +43,7 @@ class RenderTarget : public Component
 public:
     explicit RenderTarget(RenderTexture*, bool is_multiview);
     explicit RenderTarget(Scene*);
+    explicit RenderTarget(Scene*, int defaultViewportW, int defaultViewportH);
     explicit RenderTarget(RenderTexture*, const RenderTarget* source);
     RenderTarget();
     virtual ~RenderTarget();

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target_jni.cpp
@@ -33,7 +33,11 @@ extern "C" {
     Java_com_samsungxr_NativeRenderTarget_endRendering(JNIEnv *env, jobject obj, jlong ptr);
 
     JNIEXPORT jlong JNICALL
-    Java_com_samsungxr_NativeRenderTarget_defaultCtr(JNIEnv *env, jobject obj, jlong jscene);
+    Java_com_samsungxr_NativeRenderTarget_defaultCtor(JNIEnv *env, jobject obj, jlong jscene);
+
+    JNIEXPORT jlong JNICALL
+    Java_com_samsungxr_NativeRenderTarget_ctorViewport(JNIEnv *env, jobject obj, jlong jscene,
+                                                     jint defaultViewportW, jint defaultViewportH);
     JNIEXPORT void JNICALL
             Java_com_samsungxr_NativeRenderTarget_attachRenderTarget(JNIEnv *env, jobject obj, jlong jrendertarget, jlong jnextrendertarget);
     JNIEXPORT void JNICALL
@@ -60,11 +64,20 @@ Java_com_samsungxr_NativeRenderTarget_render(JNIEnv *env, jobject obj, jlong ren
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_samsungxr_NativeRenderTarget_defaultCtr(JNIEnv *env, jobject obj, jlong jscene){
+Java_com_samsungxr_NativeRenderTarget_defaultCtor(JNIEnv *env, jobject obj, jlong jscene){
     Scene* scene = reinterpret_cast<Scene*>(jscene);
     return reinterpret_cast<jlong>(Renderer::getInstance()->createRenderTarget(scene));
 
 }
+
+JNIEXPORT jlong JNICALL
+Java_com_samsungxr_NativeRenderTarget_ctorViewport(JNIEnv *env, jobject obj, jlong jscene,
+                                                 jint defaultViewportW, jint defaultViewportH){
+    Scene* scene = reinterpret_cast<Scene*>(jscene);
+    return reinterpret_cast<jlong>(Renderer::getInstance()->createRenderTarget(scene, defaultViewportW,
+                                                                               defaultViewportH));
+}
+
 JNIEXPORT jlong JNICALL
 Java_com_samsungxr_NativeRenderTarget_ctorMultiview(JNIEnv *env, jobject obj, jlong jtexture, jboolean isMultiview)
 {

--- a/SXR/SDK/sxrsdk/src/main/jni/vulkan/vk_render_target.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/vulkan/vk_render_target.cpp
@@ -32,6 +32,8 @@ VkRenderTarget::VkRenderTarget(RenderTexture* renderTexture, bool is_multiview):
 
 VkRenderTarget::VkRenderTarget(Scene* scene): RenderTarget(scene){
 }
+VkRenderTarget::VkRenderTarget(Scene* scene, int defaultViewportW, int defaultViewportH): RenderTarget(scene, defaultViewportW, defaultViewportH){
+}
 VkRenderTarget::VkRenderTarget(RenderTexture* renderTexture, const RenderTarget* source): RenderTarget(renderTexture, source){
 }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/vulkan/vk_render_target.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/vulkan/vk_render_target.h
@@ -27,6 +27,7 @@ class VkRenderTarget: public  RenderTarget
 public:
     explicit VkRenderTarget(RenderTexture* renderTexture, bool is_multiview);
     explicit VkRenderTarget(Scene* scene);
+    explicit VkRenderTarget(Scene* scene,int defaultViewportW, int defaultViewportH);
     explicit VkRenderTarget(RenderTexture* renderTexture, const RenderTarget* source);
     explicit  VkRenderTarget(){}
     virtual ~VkRenderTarget(){}


### PR DESCRIPTION
Fixes render target issues with monoscopic backend. There are two issues that have been fixed in this PR.
We are using default fbo for monoscopic backend, so our rendertargets do not have rendertextures in them. After drawing to a separate render target in case of demos such as rendertotexture, we were not unbinding the fbo and therefore, nothing was being rendered on the default fbo. The second issue was that the viewport was not being set correctly in demos such as shadows and simplephysics. 