### PR TITLE
fix daydream rendertarget issues

### DIFF
--- a/SXR/SDK/backend_daydream/src/main/java/com/samsungxr/DaydreamViewManager.java
+++ b/SXR/SDK/backend_daydream/src/main/java/com/samsungxr/DaydreamViewManager.java
@@ -31,6 +31,8 @@ class DaydreamViewManager extends SXRViewManager {
     private SXRCameraRig cameraRig;
     private boolean sensoredSceneUpdated = false;
     private  SXRRenderTarget mDaydreamRenderTarget = null;
+    private int defaultWidth = 1024;
+    private int defaultHeight = 1024;
 
     // This is done on the GL thread because refreshViewerProfile isn't thread-safe.
     private final Runnable refreshViewerProfileRunnable =
@@ -82,7 +84,8 @@ class DaydreamViewManager extends SXRViewManager {
     }
     public SXRRenderTarget getRenderTarget(){
         if(null == mDaydreamRenderTarget){
-            mDaydreamRenderTarget = new SXRRenderTarget(mApplication.getSXRContext());
+            mDaydreamRenderTarget = new SXRRenderTarget(mApplication.getSXRContext(),
+                    defaultWidth, defaultHeight);
         }
         return mDaydreamRenderTarget;
     }

--- a/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_texture.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_texture.h
@@ -50,6 +50,10 @@ public:
         glBindFramebuffer(GL_FRAMEBUFFER, renderTexture_gl_frame_buffer_->id());
     }
 
+    virtual void unbind() {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
     virtual void beginRendering(Renderer*);
     virtual void endRendering(Renderer*);
     virtual bool isReady();

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.cpp
@@ -48,8 +48,6 @@ RenderTarget::RenderTarget(RenderTexture* tex, bool is_multiview)
 }
 void RenderTarget::beginRendering(Renderer *renderer) {
     if(mRenderTexture == nullptr) {
-        //if there is no render texture as in case of monoscopic backend, we are using default fbo
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glViewport(0,0,mRenderState.viewportWidth,mRenderState.viewportHeight);
         return;
     }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/render_texture.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/render_texture.h
@@ -64,6 +64,7 @@ public:
     virtual int height() const { return getImage()->getHeight(); }
     virtual unsigned int getFrameBufferId() const = 0;
     virtual void bind() = 0;
+    virtual void unbind() = 0;
     virtual void beginRendering(Renderer*) = 0;
     virtual void endRendering(Renderer*) = 0;
 

--- a/SXR/SDK/sxrsdk/src/main/jni/view_manager_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/view_manager_jni.cpp
@@ -57,11 +57,12 @@ extern "C" {
 
         javaNode = jni->NewLocalRef(javaNode);
         renderTarget->cullFromCamera(scene, javaNode, renderTarget->getCamera(),gRenderer,shader_manager);
-        if(!gRenderer->isVulkanInstance())
-            renderTarget->beginRendering(gRenderer);
+
         gRenderer->renderRenderTarget(scene, javaNode, renderTarget,shader_manager,post_effect_render_texture_a,post_effect_render_texture_b);
-        if(!gRenderer->isVulkanInstance())
-            renderTarget->endRendering(gRenderer);
+
+        //unbind the fbo on which the drawing was done
+        if(renderTarget->getTexture())
+            renderTarget->getTexture()->unbind();
 
         jni->DeleteLocalRef(javaNode);
     }

--- a/SXR/SDK/sxrsdk/src/main/jni/vulkan/vk_render_to_texture.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/vulkan/vk_render_to_texture.h
@@ -67,6 +67,7 @@ public:
         return 0;
     }
     virtual void bind();
+    virtual void unbind(){}
     virtual void beginRendering(Renderer* renderer);
     virtual void endRendering(Renderer*){
         vkCmdEndRenderPass(mCmdBuffer);


### PR DESCRIPTION
Tested with sxr-shadows, sxr-blurfilter, sxr-simplephysics, sxr-rendertotexture on oculus, monoscopic and daydream backends.

SXR-DCO-1.0-Signed-off-by: Sushant Ojal sushant.o@samsung.com