### PR TITLE
Improve out of memory behavior

### DIFF
--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRMesh.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRMesh.java
@@ -757,7 +757,7 @@ public class SXRMesh extends SXRHybridObject implements PrettyPrint {
      * @param gvrContext    the current context
      * @param width         a number representing the width
      * @param height        a number representing the height
-     * @param centralAngle  the central angle of the arc
+     * @param centralAngle  the central angle of the arc in degrees
      * @param radius        the radius of the circle
      * @return
      */

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRTexture.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRTexture.java
@@ -182,6 +182,13 @@ public class SXRTexture extends SXRHybridObject implements SXRAndroidResource.Te
         return mTextureId;
     }
 
+    /**
+     * Clear the image data associated with this texture.
+     */
+    public void clearData()
+    {
+        NativeTexture.clearData(getNative());
+    }
 
     /**
      * Update the texture parameters {@link SXRTextureParameters} after the
@@ -252,9 +259,9 @@ public class SXRTexture extends SXRHybridObject implements SXRAndroidResource.Te
     {
         mImage = imageData;
         if (imageData != null)
-            NativeTexture.setImage(getNative(), imageData, imageData.getNative());
+            NativeTexture.setImage(getNative(), imageData.getNative());
         else
-            NativeTexture.setImage(getNative(), null, 0);
+            NativeTexture.setImage(getNative(),0);
     }
 
     /**
@@ -310,6 +317,7 @@ class NativeTexture {
     static native long constructor();
     static native int getId(long texture);
     static native boolean isReady(long texture);
+    static native void clearData(long texture);
     static native void updateTextureParameters(long texture, int[] textureParametersValues);
-    static native void setImage(long texPointer, SXRImage javeImage, long nativeImage);
+    static native void setImage(long texPointer, long nativeImage);
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/gl/gl_bitmap_image.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/gl/gl_bitmap_image.cpp
@@ -145,10 +145,14 @@ void GLBitmapImage::updateFromBitmap(int texid)
     if (mIsBuffer)
     {
         updateFromBuffer(env, mGLTarget, mBitmap);
-    } else {
+    }
+    else
+    {
         bool mipmap = false;
-        if(!mIsCompressed && mTexParams.getMinFilter() >=  TextureParameters::NEAREST_MIPMAP_NEAREST)
+        if (!mIsCompressed && mTexParams.getMinFilter() >= TextureParameters::NEAREST_MIPMAP_NEAREST)
+        {
             mipmap = true;
+        }
         updateFromBitmap(env, mGLTarget, mBitmap, mipmap, mFormat);
     }
     checkGLError("GLBitmapImage::updateFromBitmap");
@@ -164,8 +168,8 @@ void GLBitmapImage::loadCompressedMipMaps(jbyte *data, int format)
         int height = mHeight >> level;
         if (width < 1) width = 1;
         if (height < 1) height = 1;
-        glCompressedTexImage2D(mGLTarget, level, format, width, height, levelOffset, levelSize,
-                               data);
+        glCompressedTexImage2D(mGLTarget, level, format, width, height,
+                               levelOffset, levelSize, data);
     }
 }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/gl/gl_cubemap_image.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/gl/gl_cubemap_image.cpp
@@ -60,10 +60,14 @@ void GLCubemapImage::updateFromBitmap(int texid)
     {
         jobject bitmap = env->GetObjectArrayElement(bmapArray, i);
         jobject bmapref = env->NewLocalRef(bitmap);
-        GLBitmapImage::updateFromBitmap(env, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, bitmap, false, mFormat);
+        if (bmapref)
+        {
+            GLBitmapImage::updateFromBitmap(env, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, bitmap,
+                                            false, mFormat);
+        }
         env->DeleteLocalRef(bmapref);
     }
-    if(!mIsCompressed && mTexParams.getMinFilter() >=  TextureParameters::NEAREST_MIPMAP_NEAREST)
+    if (!mIsCompressed && mTexParams.getMinFilter() >= TextureParameters::NEAREST_MIPMAP_NEAREST)
         glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
 }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.cpp
@@ -146,9 +146,18 @@ void RenderData::setStencilTest(bool flag) {
 /**
  * Called when the shader for a RenderData needs to be generated on the Java side.
  */
-void RenderData::bindShader(JNIEnv* env, jobject localNode, bool isMultiview)
+int RenderData::bindShader(JNIEnv* env, jobject localNode, bool isMultiview)
 {
-    env->CallVoidMethod(bindShaderObject_, bindShaderMethod_, localNode, isMultiview);
+    if (bindShaderObject_)
+    {
+        env->CallVoidMethod(bindShaderObject_, bindShaderMethod_, localNode, isMultiview);
+        if (env->ExceptionCheck())
+        {
+            LOGE("RENDER", "EXCEPTION in RenderData::bindShader");
+            return 0;
+        }
+    }
+    return 1;
 }
 
 bool compareRenderDataByShader(RenderData *i, RenderData *j)
@@ -290,7 +299,10 @@ int RenderData::isValid(Renderer* renderer, const RenderState& rstate)
         JNIEnv* env = nullptr;
         int rc = rstate.scene->get_java_env(&env);
 
-        bindShader(env, rstate.javaNode, rstate.is_multiview);
+        if (!bindShader(env, rstate.javaNode, rstate.is_multiview))
+        {
+            return -1;
+        }
         if (rc > 0)
         {
             rstate.scene->detach_java_env();

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.h
@@ -150,7 +150,7 @@ public:
      * Select or generate a shader for this render data.
      * This function executes a Java task on the Framework thread.
      */
-    void bindShader(JNIEnv* env, jobject localNode, bool);
+    int bindShader(JNIEnv* env, jobject localNode, bool);
     void markDirty() {
         render_data_flags.dirty_ = true;
     }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer.cpp
@@ -45,14 +45,14 @@ namespace sxr {
     {
         if (mIndexData != nullptr)
         {
-            delete [] mIndexData;
+            free(mIndexData);
             mIndexData = nullptr;
         }
         mIndexCount = 0;
     }
 
 
-    bool    IndexBuffer::setShortVec(const unsigned short* src, int srcSize)
+    int IndexBuffer::setShortVec(const unsigned short* src, int srcSize)
     {
         unsigned short*  dest;
         std::lock_guard<std::mutex> lock(mUpdateLock);
@@ -60,24 +60,28 @@ namespace sxr {
         if (src == nullptr)
         {
             LOGE("IndexBuffer: source array not found");
-            return false;
+            return 0;
         }
-        else if (!setIndexCount(srcSize))
+        else
         {
-            return false;
+            int rc = setIndexCount(srcSize);
+            if (rc <= 0)
+            {
+                return rc;
+            }
         }
         if (mIndexByteSize != sizeof(short))
         {
             LOGE("IndexBuffer: cannot change type of index data");
-            return false;
+            return 0;
         }
         dest = reinterpret_cast<unsigned short*>(mIndexData);
         memcpy(dest, src, srcSize * sizeof(short));
         mIsDirty = true;
-        return true;
+        return 1;
     }
 
-    bool    IndexBuffer::setIntVec(const unsigned int* src, int srcSize)
+    int IndexBuffer::setIntVec(const unsigned int* src, int srcSize)
     {
         unsigned int*   dest;
         std::lock_guard<std::mutex> lock(mUpdateLock);
@@ -85,21 +89,25 @@ namespace sxr {
         if (src == nullptr)
         {
             LOGE("IndexBuffer: source array not found");
-            return false;
+            return 0;
         }
-        else if (!setIndexCount(srcSize))
+        else
         {
-            return false;
+            int rc = setIndexCount(srcSize);
+            if (rc <= 0)
+            {
+                return rc;
+            }
         }
         if (mIndexByteSize != sizeof(int))
         {
             LOGE("IndexBuffer: cannot change type of index data");
-            return false;
+            return 0;
         }
         dest = reinterpret_cast<unsigned int*>(mIndexData);
         memcpy(dest, src, srcSize * sizeof(int));
         mIsDirty = true;
-        return true;
+        return 1;
     }
 
     bool    IndexBuffer::getShortVec(unsigned short* dest, int destSize) const
@@ -161,34 +169,36 @@ namespace sxr {
         return mIndexCount;
     }
 
-    bool IndexBuffer::setIndexCount(int count)
+    int IndexBuffer::setIndexCount(int count)
     {
         if (mIndexByteSize <= 0)
         {
-            return false;
+            return 0;
         }
         if ((mIndexCount != 0) && (mIndexCount != count))
         {
             LOGE("IndexBuffer: cannot change size of index array from %d to %d", mIndexCount, count);
-            return false;
+            return 0;
         }
         if (mIndexCount == count)
         {
             return true;
         }
-        mIndexCount = count;
         if (count > 0)
         {
             int datasize = mIndexByteSize * count;
             LOGV("IndexBuffer: %p allocating index buffer of %d bytes\n", this, datasize);
-            mIndexData = new char[datasize];
-            return true;
+            mIndexData = (char*) malloc(datasize);
+            if (mIndexData != nullptr)
+            {
+                mIndexCount = count;
+                return 1;
+            }
+            LOGE("IndexBuffer: out of memory cannot allocate room for %d bytes\n", datasize);
+            return -1;
         }
-        else
-        {
-            LOGE("IndexBuffer: ERROR: no index buffer allocated\n");
-            return false;
-        }
+        LOGE("IndexBuffer: ERROR: no index buffer allocated\n");
+        return 0;
     }
 
     void IndexBuffer::dump() const

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer.cpp
@@ -182,7 +182,7 @@ namespace sxr {
         }
         if (mIndexCount == count)
         {
-            return true;
+            return 1;
         }
         if (count > 0)
         {

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer.h
@@ -51,20 +51,20 @@ namespace sxr {
          *
          * @param src         pointer to short integer source data array.
          * @param srcSize     number of shorts in the vector.
-         * @returns true if successfully set, false on error.
+         * @returns 1 if successfully set, 0 on error, -1 if out of memory.
          * @see getShortVec
          */
-        bool    setShortVec(const unsigned short* src, int srcSize);
+        int setShortVec(const unsigned short* src, int srcSize);
 
         /**
          * Set all the values for long (32 bit) indices.
          *
          * @param src         pointer to integer source data array.
          * @param srcSize     number of ints in the vector.
-         * @returns true if successfully set, false on error.
+         * @returns 1 if successfully set, 0 on error, -1 if out of memory.
          * @see getIntVec
          */
-        bool    setIntVec(const unsigned int* src, int srcSize);
+        int setIntVec(const unsigned int* src, int srcSize);
 
         /**
          * Gets all the values for long (32 bit) indices.
@@ -92,7 +92,7 @@ namespace sxr {
         void            dump() const;
 
     protected:
-        bool            setIndexCount(int count);
+        int             setIndexCount(int count);
         bool            setIndexSize(int v);
 
         mutable std::mutex mUpdateLock;

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/index_buffer_jni.cpp
@@ -195,7 +195,7 @@ Java_com_samsungxr_NativeIndexBuffer_setIntArray(JNIEnv * env, jobject obj, jlon
 
     if (data && (n > 0))
     {
-        ibuf->setIntVec(data, n);
+        rc = ibuf->setIntVec(data, n);
     }
     env->ReleaseIntArrayElements(jdata, reinterpret_cast<jint*>(data), 0);
     if (rc < 0)

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/bitmap_image.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/bitmap_image.cpp
@@ -46,7 +46,10 @@ void BitmapImage::update(JNIEnv* env, int width, int height, jbyteArray data)
     if (data != NULL)
     {
         mData = static_cast<jbyteArray>(env->NewGlobalRef(data));
-        signalUpdate();
+        if (mData)
+        {
+            signalUpdate();
+        }
     }
 }
 
@@ -60,6 +63,10 @@ void BitmapImage::update(JNIEnv* env, jobject bitmap, bool hasAlpha, int format)
         mBitmap = static_cast<jbyteArray>(env->NewGlobalRef(bitmap));
         mFormat = format;
         mIsBuffer = false;
+        if (mBitmap == nullptr)
+        {
+            return;
+        }
         if (hasAlpha)
         {
             if (bitmap_has_transparency(env, bitmap))
@@ -90,7 +97,10 @@ void BitmapImage::update(JNIEnv* env, int xoffset, int yoffset, int width, int h
         mType = type;
         mBitmap = env->NewGlobalRef(buffer);
         mIsBuffer = true;
-        signalUpdate();
+        if (mBitmap)
+        {
+            signalUpdate();
+        }
     }
 }
 
@@ -109,11 +119,14 @@ void BitmapImage::update(JNIEnv *env, int width, int height, int imageSize,
     if (data != NULL)
     {
         mData = static_cast<jbyteArray>(env->NewGlobalRef(data));
-        mPixels = env->GetByteArrayElements(mData, 0);
-        set_transparency(hasAlpha(mFormat));
-        env->ReleaseByteArrayElements(mData, mPixels, 0);
-        mPixels = NULL;
-        signalUpdate();
+        if (mData)
+        {
+            mPixels = env->GetByteArrayElements(mData, 0);
+            set_transparency(hasAlpha(mFormat));
+            env->ReleaseByteArrayElements(mData, mPixels, 0);
+            mPixels = NULL;
+            signalUpdate();
+        }
     }
 }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/bitmap_image.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/bitmap_image.cpp
@@ -60,10 +60,14 @@ void BitmapImage::update(JNIEnv* env, jobject bitmap, bool hasAlpha, int format)
         mBitmap = static_cast<jbyteArray>(env->NewGlobalRef(bitmap));
         mFormat = format;
         mIsBuffer = false;
-        if( hasAlpha ) {
-            if(bitmap_has_transparency(env, bitmap)) {
+        if (hasAlpha)
+        {
+            if (bitmap_has_transparency(env, bitmap))
+            {
                 set_transparency(true);
-            } else {
+            }
+            else
+            {
                 LOGW("BitmapImage: bitmap has an alpha channel with no translucent/transparent pixels.");
             }
         }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/bitmap_image.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/bitmap_image.h
@@ -50,8 +50,7 @@ namespace sxr {
             return mHasTransparency;
         }
 
-    protected:
-        void clearData(JNIEnv* env);
+        virtual void clearData(JNIEnv* env);
 
     private:
         BitmapImage(const BitmapImage& texture) = delete;

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/cubemap_image.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/cubemap_image.h
@@ -42,6 +42,7 @@ namespace sxr {
         void update(JNIEnv* env, jobjectArray bitmapArray);
         void update(JNIEnv* env, int width, int height, int imageSize,
                     jobjectArray textureArray, const int* textureOffset);
+        virtual void clearData(JNIEnv* env);
 
     private:
         CubemapImage(const CubemapImage& base_texture) = delete;
@@ -50,7 +51,6 @@ namespace sxr {
         CubemapImage& operator=(CubemapImage&& base_texture) = delete;
 
     protected:
-        void clearData(JNIEnv* env);
         void updateFromBitmap(int texid);
         void updateFromMemory(int texid);
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/float_image.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/float_image.cpp
@@ -45,7 +45,10 @@ namespace sxr {
         if (data != NULL)
         {
             mData = static_cast<jfloatArray>(env->NewGlobalRef(data));
-            signalUpdate();
+            if (mData)
+            {
+                signalUpdate();
+            }
         }
     }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/float_image.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/float_image.h
@@ -31,9 +31,7 @@ namespace sxr {
         FloatImage(int pixelFormat = GL_RG);
         virtual ~FloatImage();
         void update(JNIEnv* env, int width, int height, jfloatArray data, int pixelFormat = 0);
-
-    protected:
-        void clearData(JNIEnv* env);
+        virtual void clearData(JNIEnv* env);
 
     private:
         FloatImage(const FloatImage&) = delete;

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/image.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/image.h
@@ -20,9 +20,11 @@
 #include <string>
 #include <mutex>
 #include <vector>
+#include <jni.h>
 #include "objects/hybrid_object.h"
 #include "util/sxr_log.h"
 #include "gl/gl_headers.h"  // for GL_TEXTURE_xxx
+
 
 namespace sxr {
 class Texture;
@@ -83,6 +85,7 @@ public:
     virtual bool isReady() = 0;
     virtual void texParamsChanged(const TextureParameters&) = 0;
     virtual bool transparency() { return false; }
+    virtual void clearData(JNIEnv* env) { }
 
     bool hasData() const { return mState == HAS_DATA; }
     short getWidth() const { return mWidth; }
@@ -125,6 +128,12 @@ public:
             updateComplete();
         }
         return hasData();
+    }
+
+    void clear(JNIEnv* env)
+    {
+        std::lock_guard<std::mutex> lock(mUpdateLock);
+        clearData(env);
     }
 
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture.cpp
@@ -32,8 +32,7 @@ Texture::Texture(int type)
           mTexParamsDirty(false),
           mType(type),
           mImage(NULL),
-          mJava(NULL),
-          mJavaImage(NULL)
+          mJava(NULL)
 { }
 
 Texture::~Texture()
@@ -58,12 +57,12 @@ bool Texture::isReady()
 
 void Texture::clearData(JNIEnv* env)
 {
-    if (mJavaImage)
+    Image* image = mImage;
+    if (image)
     {
-        env->DeleteWeakGlobalRef(mJavaImage);
-        mJavaImage = NULL;
+        image->clear(env);
     }
-    mImage = NULL;
+    LOGV("Texture::clearImage %p", this);
 }
 
 void Texture::setImage(Image* image)
@@ -75,7 +74,7 @@ void Texture::setImage(Image* image)
     mImage = image;
 }
 
-void Texture::setImage(JNIEnv* env, jobject javaImage, Image* image)
+void Texture::setImage(JNIEnv* env, Image* image)
 {
     if (JNI_OK != env->GetJavaVM(&mJava))
     {
@@ -83,13 +82,12 @@ void Texture::setImage(JNIEnv* env, jobject javaImage, Image* image)
         return;
     }
     clearData(env);
-    mJavaImage = env->NewWeakGlobalRef(javaImage);
     mImage = image;
     if (image)
     {
         image->texParamsChanged(getTexParams());
     }
-    LOGV("Texture::setImage");
+    LOGV("Texture::setImage %p", this);
 }
 
 void Texture::updateTextureParameters(const int* texture_parameters, int n)

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture.h
@@ -151,7 +151,7 @@ public:
     explicit Texture(int type = TEXTURE_2D);
     virtual ~Texture();
     void setImage(Image* image);
-    void setImage(JNIEnv* env, jobject javaImage, Image* image);
+    void setImage(JNIEnv* env, Image* image);
     void updateTextureParameters(const int* texture_parameters, int n);
 
     int getType() const { return mType; }
@@ -172,9 +172,10 @@ public:
         return image && image->transparency();
     }
 
+    void clearData(JNIEnv* env);
+
 protected:
     JavaVM* mJava;
-    jobject mJavaImage;
     int     mType;
     bool    mTexParamsDirty;
     TextureParameters   mTexParams;
@@ -182,7 +183,6 @@ protected:
 private:
     //since it can be read/written from the gl and other threads concurrently
     std::atomic<Image*> mImage;
-    void clearData(JNIEnv* env);
 
     Texture(const Texture& texture) = delete;
     Texture(Texture&& texture) = delete;

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture_jni.cpp
@@ -32,6 +32,9 @@ extern "C" {
     Java_com_samsungxr_NativeTexture_isReady(JNIEnv * env, jobject obj, jlong jtexture);
 
     JNIEXPORT void JNICALL
+    Java_com_samsungxr_NativeTexture_clearData(JNIEnv * env, jobject obj, jlong jtexture);
+
+    JNIEXPORT void JNICALL
     Java_com_samsungxr_NativeTexture_updateTextureParameters(JNIEnv * env, jobject obj,
                 jlong jtexture, jintArray jtexture_parameters);
 
@@ -40,7 +43,7 @@ extern "C" {
 
     JNIEXPORT void JNICALL
     Java_com_samsungxr_NativeTexture_setImage(JNIEnv * env, jobject obj,
-                jlong jtexture, jobject javaImage, jlong nativeImage);
+                jlong jtexture, jlong nativeImage);
 }
 ;
 
@@ -65,6 +68,12 @@ Java_com_samsungxr_NativeTexture_isReady(JNIEnv * env, jobject obj, jlong jtextu
     return texture->isReady();
 }
 
+JNIEXPORT void JNICALL
+Java_com_samsungxr_NativeTexture_clearData(JNIEnv* env, jobject obj, jlong jtexture)
+{
+    Texture* texture = reinterpret_cast<Texture*>(jtexture);
+    texture->clearData(env);
+}
 
 JNIEXPORT void JNICALL
 Java_com_samsungxr_NativeTexture_updateTextureParameters(JNIEnv * env, jobject obj,
@@ -79,10 +88,10 @@ Java_com_samsungxr_NativeTexture_updateTextureParameters(JNIEnv * env, jobject o
 
 JNIEXPORT void JNICALL
 Java_com_samsungxr_NativeTexture_setImage(JNIEnv* env, jobject obj, jlong jtexture,
-                                        jobject javaImage, jlong nativeImage)
+                                        jlong nativeImage)
 {
     Texture* texture = reinterpret_cast<Texture*>(jtexture);
     Image* image = reinterpret_cast<Image*>(nativeImage);
-    texture->setImage(env, javaImage, image);
+    texture->setImage(env, image);
 }
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/vertex_buffer.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/vertex_buffer.h
@@ -70,10 +70,10 @@ namespace sxr {
          * @param src         pointer to integer source data array.
          * @param srcSize     number of floats in the vector.
          * @param srcStride   number of floats to the next vertex.
-         * @returns true if successfully set, false on error.
+         * @returns 1 if successfully set, 0 on error, -1 if out of memory.
          * @see getIntVec
          */
-        bool    setFloatVec(const char* attributeName, const float* src, int srcSize, int srcStride);
+        int setFloatVec(const char* attributeName, const float* src, int srcSize, int srcStride);
 
         /**
          * Gets all the values of a float vertex attribute.
@@ -88,7 +88,7 @@ namespace sxr {
          * @param dest        pointer to integer source data array.
          * @param destSize    number of floats in the vector.
          * @param destStride  number of floats to the next vertex.
-         * @return true if vector retrieved, false if not found or size is wrong.
+         * @returns true if successfully set, false on error.
          * @see setVec
          */
         bool    getFloatVec(const char* attributeName, float* dest, int destSize, int destStride) const;
@@ -105,10 +105,10 @@ namespace sxr {
          * @param src         pointer to integer source data array.
          * @param srcSize     number of integers in the vector.
          * @param srcStride   number of integers to the next vertex.
-         * @returns true if successfully set, false on error.
+         * @returns 1 if successfully set, 0 on error, -1 if out of memory.
          * @see getIntVec
          */
-        bool            setIntVec(const char* attributeName, const int* src, int srcSize, int srcStride);
+        int setIntVec(const char* attributeName, const int* src, int srcSize, int srcStride);
 
         /**
          * Gets all the values of an integer vertex attribute.
@@ -138,7 +138,7 @@ namespace sxr {
         void            dump(const char* attrName) const;
 
     protected:
-        bool            setVertexCount(int vertexCount);
+        int             setVertexCount(int vertexCount);
         const void*     getData(const char* attributeName, int& size) const;
         const void*     getData(int index, int& size) const;
 

--- a/SXR/SDK/sxrsdk/src/main/jni/util/jni_utils.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/util/jni_utils.h
@@ -68,4 +68,14 @@ static JNIEnv* getCurrentEnv(JavaVM* javaVm) {
 static const int SUPPORTED_JNI_VERSION = JNI_VERSION_1_6;
 }
 
+static jint throwOutOfMemoryError(JNIEnv* env, const char *message)
+{
+    jclass exClass = env->FindClass("java/lang/OutOfMemoryError");
+
+    if (exClass != NULL)
+    {
+        return env->ThrowNew(exClass, message);
+    }
+    return -1;
+}
 #endif


### PR DESCRIPTION
1. Throw out of memory exceptions from vertex and index buffers
2. Check for exceptions in bindShaderNative
3. Add SXRImage.clearData() to allow test to clear C++ references to image (like the rendering loop does)
4. Removed weak reference to unused java image

SXR DCO signed off by: Nola Donato nola.donato@samsung.com