### PR TITLE
Fix for the TestSendEvents test - controller class sending events now to the right target (app)

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
@@ -268,7 +268,7 @@ public class SXRMixedReality implements IMixedReality
         return mSession.makeInterpolated(poseA, poseB, t);
     }
 
-    private class ActivityEventsHandler extends SXREventListeners.ActivityEvents {
+    private class ActivityEventsHandler extends SXREventListeners.ApplicationEvents {
         @Override
         public void onPause() {
             pause();

--- a/SXR/Extensions/ResonanceAudio/resonanceaudio/src/main/java/com/samsungxr/resonanceaudio/SXRAudioManager.java
+++ b/SXR/Extensions/ResonanceAudio/resonanceaudio/src/main/java/com/samsungxr/resonanceaudio/SXRAudioManager.java
@@ -18,12 +18,12 @@ package com.samsungxr.resonanceaudio;
 import android.app.Activity;
 
 import com.google.vr.sdk.audio.GvrAudioEngine;
-
 import com.samsungxr.SXRCameraRig;
 import com.samsungxr.SXRContext;
 import com.samsungxr.SXRDrawFrameListener;
 import com.samsungxr.SXREventListeners;
 import com.samsungxr.SXRTransform;
+
 import org.joml.Quaternionf;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ import java.util.List;
  * tracks the head transform so the sound will be spatially
  * correct.
  */
-public class SXRAudioManager extends SXREventListeners.ActivityEvents
+public class SXRAudioManager extends SXREventListeners.ApplicationEvents
         implements SXRDrawFrameListener
 {
     private static final String TAG = SXRAudioManager.class.getSimpleName();

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/IApplicationEvents.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/IApplicationEvents.java
@@ -30,7 +30,7 @@ import org.joml.Vector3f;
  * User can add a listener to {@code SXRActivity.getEventReceiver()} to handle
  * these events, rather than subclassing {@link SXRActivity}.
  */
-public interface IActivityEvents extends IEvents {
+public interface IApplicationEvents extends IEvents {
     void onPause();
 
     void onResume();

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRApplication.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRApplication.java
@@ -225,7 +225,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             mViewManager.getEventManager().sendEventWithMask(
                     SEND_EVENT_MASK,
                     this,
-                    IActivityEvents.class,
+                    IApplicationEvents.class,
                     "onPause");
         }
     }
@@ -245,7 +245,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             mViewManager.getEventManager().sendEventWithMask(
                     SEND_EVENT_MASK,
                     this,
-                    IActivityEvents.class,
+                    IApplicationEvents.class,
                     "onResume");
         }
     }
@@ -262,7 +262,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             mViewManager.getEventManager().sendEventWithMask(
                     SEND_EVENT_MASK,
                     this,
-                    IActivityEvents.class,
+                    IApplicationEvents.class,
                     "onDestroy");
             mViewManager = null;
         }
@@ -384,7 +384,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
         mViewManager.getEventManager().sendEventWithMask(
                 SEND_EVENT_MASK,
                 this,
-                IActivityEvents.class,
+                IApplicationEvents.class,
                 "dispatchKeyEvent", event);
 
         if (mViewManager.dispatchKeyEvent(event)) {
@@ -452,7 +452,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
         mViewManager.getEventManager().sendEventWithMask(
                 SEND_EVENT_MASK,
                 this,
-                IActivityEvents.class,
+                IApplicationEvents.class,
                 "dispatchTouchEvent", event);
 
         return handled;
@@ -469,7 +469,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             mViewManager.getEventManager().sendEventWithMask(
                     SEND_EVENT_MASK,
                     this,
-                    IActivityEvents.class,
+                    IApplicationEvents.class,
                     "onConfigurationChanged", newConfig);
         }
     }
@@ -484,7 +484,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             mViewManager.getEventManager().sendEventWithMask(
                     SEND_EVENT_MASK,
                     this,
-                    IActivityEvents.class,
+                    IApplicationEvents.class,
                     "onTouchEvent", event);
         }
 
@@ -500,7 +500,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             mViewManager.getEventManager().sendEventWithMask(
                     SEND_EVENT_MASK,
                     this,
-                    IActivityEvents.class,
+                    IApplicationEvents.class,
                     "onWindowFocusChanged", hasFocus);
         }
 
@@ -646,7 +646,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             mViewManager.getEventManager().sendEventWithMask(
                     SEND_EVENT_MASK,
                     this,
-                    IActivityEvents.class,
+                    IApplicationEvents.class,
                     "onSetMain", sxrMain);
 
             final SXRConfigurationManager localConfigurationManager = mConfigurationManager;
@@ -726,7 +726,7 @@ public final class SXRApplication implements IEventReceiver, IScriptable {
             }
         };
         mGestureDetector = new GestureDetector(mActivity.getApplicationContext(), gestureListener);
-        getEventReceiver().addListener(new SXREventListeners.ActivityEvents() {
+        getEventReceiver().addListener(new SXREventListeners.ApplicationEvents() {
             @Override
             public void dispatchTouchEvent(MotionEvent event) {
                 mGestureDetector.onTouchEvent(event);

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXREventListeners.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXREventListeners.java
@@ -13,7 +13,7 @@ import org.joml.Vector3f;
 
 /**
  * This class contains null implementations for the event interfaces
- * (subclasses of {@link IEvents}, such as {@link IScriptEvents} and {@link IActivityEvents}).
+ * (subclasses of {@link IEvents}, such as {@link IScriptEvents} and {@link IApplicationEvents}).
  * They can be extended to override individual methods, which produces less code than
  * implementing the complete interfaces, when the latter is unnecessary.
  *
@@ -57,9 +57,9 @@ public class SXREventListeners {
     }
 
     /**
-     * Null implementation of {@link IActivityEvents}.
+     * Null implementation of {@link IApplicationEvents}.
      */
-    public static class ActivityEvents implements IActivityEvents {
+    public static class ApplicationEvents implements IApplicationEvents {
         @Override
         public void onPause() {
         }

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/io/SXRAndroidWearTouchpad.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/io/SXRAndroidWearTouchpad.java
@@ -30,7 +30,7 @@ import android.util.Log;
 import android.view.MotionEvent;
 
 import com.samsungxr.SXRContext;
-import com.samsungxr.SXREventListeners.ActivityEvents;
+import com.samsungxr.SXREventListeners.ApplicationEvents;
 import com.samsungxr.SXREventManager;
 
 class SXRAndroidWearTouchpad {
@@ -55,7 +55,7 @@ class SXRAndroidWearTouchpad {
         gvrContext = context;
         activity = gvrContext.getActivity();
         eventManager = gvrContext.getEventManager();
-        gvrContext.getApplication().getEventReceiver().addListener(new ActivityPauseEvent());
+        gvrContext.getApplication().getEventReceiver().addListener(new ApplicationPauseEvent());
         connectToWatch();
     }
 
@@ -141,7 +141,7 @@ class SXRAndroidWearTouchpad {
         }
     }
 
-    private class ActivityPauseEvent extends ActivityEvents {
+    private class ApplicationPauseEvent extends ApplicationEvents {
         @Override
         public void onPause() {
             super.onPause();

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/io/SXRGearCursorController.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/io/SXRGearCursorController.java
@@ -16,13 +16,13 @@
 
 package com.samsungxr.io;
 
-import android.app.Activity;
 import android.graphics.PointF;
 import android.os.SystemClock;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
+import com.samsungxr.SXRApplication;
 import com.samsungxr.SXRContext;
 import com.samsungxr.SXREventManager;
 import com.samsungxr.SXREventReceiver;
@@ -32,7 +32,7 @@ import com.samsungxr.SXRPicker;
 import com.samsungxr.SXRRenderData;
 import com.samsungxr.SXRScene;
 import com.samsungxr.SXRNode;
-import com.samsungxr.IActivityEvents;
+import com.samsungxr.IApplicationEvents;
 import com.samsungxr.nodes.SXRLineNode;
 import com.samsungxr.utility.Log;
 import org.joml.Matrix4f;
@@ -520,7 +520,7 @@ public final class SXRGearCursorController extends SXRCursorController
 
     private void handleControllerEvent(final ControllerEvent event)
     {
-        context.getEventManager().sendEvent(context.getApplication(), IActivityEvents.class,
+        context.getEventManager().sendEvent(context.getApplication(), IApplicationEvents.class,
                                             "onControllerEvent",
                                             CONTROLLER_KEYS.fromValue(event.key), event.position, event.rotation, event.pointF,
                                             event.touched, event.angularAcceleration,event.angularVelocity);
@@ -814,13 +814,13 @@ public final class SXRGearCursorController extends SXRCursorController
         }
 
         public void run() {
-            final Activity activity = mContext.getActivity();
+            final SXRApplication application = mContext.getApplication();
             for (final Iterator<KeyEvent> it = mKeyEvents.iterator(); it.hasNext(); ) {
                 final KeyEvent e = it.next();
                 mContext.getEventManager().sendEventWithMask(
                         SXREventManager.SEND_MASK_ALL & ~SXREventManager.SEND_MASK_OBJECT,
-                        activity,
-                        IActivityEvents.class,
+                        application,
+                        IApplicationEvents.class,
                         "dispatchKeyEvent", e);
                 it.remove();
             }
@@ -833,8 +833,8 @@ public final class SXRGearCursorController extends SXRCursorController
                 //@todo move the io package back to gearvrf
                 mContext.getEventManager().sendEventWithMask(
                         SXREventManager.SEND_MASK_ALL & ~SXREventManager.SEND_MASK_OBJECT,
-                        activity,
-                        IActivityEvents.class,
+                        application,
+                        IApplicationEvents.class,
                         "dispatchTouchEvent", dupe);
 
                 dupe.recycle();

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRCameraNode.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRCameraNode.java
@@ -40,13 +40,12 @@ import java.io.IOException;
 public class SXRCameraNode extends SXRNode {
     private static String TAG = SXRCameraNode.class.getSimpleName();
     private final SurfaceTexture mSurfaceTexture;
-    private boolean mPaused = false;
     private Camera camera;
     private SXRContext gvrContext;
     private boolean cameraSetUpStatus;
     private int fpsMode = -1;
     private boolean isCameraOpen = false;
-    private CameraActivityEvents cameraActivityEvents;
+    private CameraApplicationEvents cameraApplicationEvents;
 
     /**
      * Create a {@linkplain SXRNode node} (with arbitrarily
@@ -54,7 +53,7 @@ public class SXRCameraNode extends SXRNode {
      *
      * @param gvrContext current {@link SXRContext}
      * @param mesh       an arbitrarily complex {@link SXRMesh} object - see
-     *                   {@link SXRContext#loadMesh(com.samsungxr.SXRAndroidResource)}
+     *                   {@link com.samsungxr.SXRAssetLoader#loadMesh(com.samsungxr.SXRAndroidResource)}
      *                   and {@link SXRContext#createQuad(float, float)}
      * @param camera     an Android {@link Camera}. <em>Note</em>: this constructor
      *                   calls {@link Camera#setPreviewTexture(SurfaceTexture)} so you
@@ -103,7 +102,7 @@ public class SXRCameraNode extends SXRNode {
      *
      * @param gvrContext current {@link SXRContext}
      * @param mesh       an arbitrarily complex {@link SXRMesh} object - see
-     *                   {@link SXRContext#loadMesh(com.samsungxr.SXRAndroidResource)}
+     *                   {@link com.samsungxr.SXRAssetLoader#loadMesh(com.samsungxr.SXRAndroidResource)}
      *                   and {@link SXRContext#createQuad(float, float)}
      * @throws SXRCameraAccessException returns this exception when the camera cannot be
      *                                  initialized correctly.
@@ -138,8 +137,8 @@ public class SXRCameraNode extends SXRNode {
             throw new SXRCameraAccessException("Cannot open the camera");
         }
 
-        cameraActivityEvents = new CameraActivityEvents();
-        gvrContext.getApplication().getEventReceiver().addListener(cameraActivityEvents);
+        cameraApplicationEvents = new CameraApplicationEvents();
+        gvrContext.getApplication().getEventReceiver().addListener(cameraApplicationEvents);
     }
 
     /**
@@ -217,10 +216,9 @@ public class SXRCameraNode extends SXRNode {
         isCameraOpen = false;
     }
 
-    private class CameraActivityEvents extends SXREventListeners.ActivityEvents {
+    private class CameraApplicationEvents extends SXREventListeners.ApplicationEvents {
         @Override
         public void onPause() {
-            mPaused = true;
             closeCamera();
         }
 
@@ -230,34 +228,7 @@ public class SXRCameraNode extends SXRNode {
                 //restore fpsmode
                 setUpCameraForVrMode(fpsMode);
             }
-            mPaused = false;
         }
-    }
-
-    /**
-     * Resumes camera preview
-     *
-     * <p>
-     * Note: {@link #pause()} and {@code resume()} only affect the polling that
-     * links the Android {@link Camera} to this {@linkplain SXRNode SXRF
-     * node:} they have <em>no affect</em> on the underlying
-     * {@link Camera} object.
-     */
-    public void resume() {
-        mPaused = false;
-    }
-
-    /**
-     * Pauses camera preview
-     *
-     * <p>
-     * Note: {@code pause()} and {@link #resume()} only affect the polling that
-     * links the Android {@link Camera} to this {@linkplain SXRNode SXRF
-     * node:} they have <em>no affect</em> on the underlying
-     * {@link Camera} object.
-     */
-    public void pause() {
-        mPaused = true;
     }
 
     /**
@@ -265,8 +236,8 @@ public class SXRCameraNode extends SXRNode {
      */
     public void close() {
         closeCamera();
-        if(cameraActivityEvents != null){
-            gvrContext.getApplication().getEventReceiver().removeListener(cameraActivityEvents);
+        if(cameraApplicationEvents != null){
+            gvrContext.getApplication().getEventReceiver().removeListener(cameraApplicationEvents);
         }
     }
 

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRVideoNode.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRVideoNode.java
@@ -45,11 +45,11 @@ public class SXRVideoNode extends SXRNode {
         public static final int VERTICAL_STEREO = 2;
     };
 
-    private static class ActivityEventsListener extends SXREventListeners.ActivityEvents {
+    private static class ApplicationEventsListener extends SXREventListeners.ApplicationEvents {
         private boolean wasPlaying;
         private SXRVideoNodePlayer mPlayer;
 
-        private ActivityEventsListener(SXRVideoNodePlayer player) {
+        private ApplicationEventsListener(SXRVideoNodePlayer player) {
             mPlayer = player;
         }
 
@@ -66,7 +66,7 @@ public class SXRVideoNode extends SXRNode {
             }
         }
     };
-    private ActivityEventsListener mActivityEventsListener;
+    private ApplicationEventsListener mApplicationEventsListener;
 
     /**
      * Play a video on a {@linkplain SXRNode node} with an
@@ -153,8 +153,6 @@ public class SXRVideoNode extends SXRNode {
      *            a {@link SXRExternalTexture} to link with {@link MediaPlayer}
      * @param videoType
      *            One of the {@linkplain SXRVideoType video type constants}
-     * @throws IllegalArgumentException
-     *             on an invalid {@code videoType} parameter
      */
     public SXRVideoNode(final SXRContext gvrContext, SXRMesh mesh,
                                final SXRVideoNodePlayer mediaPlayer, final SXRExternalTexture texture,
@@ -163,8 +161,8 @@ public class SXRVideoNode extends SXRNode {
         SXRShaderId materialType;
 
         gvrVideoNodePlayer = mediaPlayer;
-        mActivityEventsListener = new ActivityEventsListener(gvrVideoNodePlayer);
-        gvrContext.getApplication().getEventReceiver().addListener(mActivityEventsListener);
+        mApplicationEventsListener = new ApplicationEventsListener(gvrVideoNodePlayer);
+        gvrContext.getApplication().getEventReceiver().addListener(mApplicationEventsListener);
 
         switch (videoType) {
             case SXRVideoType.MONO:
@@ -317,7 +315,7 @@ public class SXRVideoNode extends SXRNode {
      * {@link MediaPlayer}, if any
      */
     public void release() {
-        getSXRContext().getApplication().getEventReceiver().removeListener(mActivityEventsListener);
+        getSXRContext().getApplication().getEventReceiver().removeListener(mApplicationEventsListener);
         if (mVideo == null) {
             return;
         }
@@ -343,7 +341,7 @@ public class SXRVideoNode extends SXRNode {
     @Override
     protected void finalize() throws Throwable {
         try {
-            getSXRContext().getApplication().getEventReceiver().removeListener(mActivityEventsListener);
+            getSXRContext().getApplication().getEventReceiver().removeListener(mApplicationEventsListener);
             if (null != mVideo) {
                 mVideo.release();
             }


### PR DESCRIPTION
Renamed IActivityEvents to the more appropriate IApplicationEvents (since the app is the target for these)

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>