### PR TITLE
Fix lighting regressions

### DIFF
--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
@@ -974,7 +974,7 @@ class  SXRJassimpAdapter
             }
         }
         else if ("".equals(nodeName) &&
-                ((aiChild = handleNoName(node, sceneObject)) != null))
+                ((aiChild = handleNoName(node, sceneObject, lightlist)) != null))
         {
             node = aiChild;
         }
@@ -984,7 +984,7 @@ class  SXRJassimpAdapter
         }
     }
 
-    private AiNode handleNoName(AiNode ainode, SXRNode gvrnode)
+    private AiNode handleNoName(AiNode ainode, SXRNode gvrnode, Hashtable<String, SXRLight> lightlist)
     {
         if (ainode.getNumChildren() > 1)
         {
@@ -998,6 +998,10 @@ class  SXRJassimpAdapter
             return null;
         }
         if (aichild.getNumMeshes() > 0)
+        {
+            return null;
+        }
+        if (lightlist.containsKey(childName))
         {
             return null;
         }
@@ -1040,6 +1044,7 @@ class  SXRJassimpAdapter
             q.normalize();
             light.setDefaultOrientation(q);
             sceneObject.attachLight(light);
+            lightlist.remove(light);
         }
     }
 

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
@@ -948,7 +948,7 @@ class  SXRJassimpAdapter
             if ("".equals(nodeName))
             {
                 if ((mNodeMap.get(parent) == null) ||
-                    ((aiChild = handleNoName(node, sceneObject)) == null))
+                    ((aiChild = handleNoName(node, sceneObject, lightlist)) == null))
                 {
                     nodeName = "mesh";
                     sceneObject.setName(nodeName + "-" + meshId);


### PR DESCRIPTION
1. Fix regression adding lights which have parents without names
2. Fix long standing problem adding lights when replacing current scene
   The asset loader now adds new nodes to the scene on the GL thread so that new lights are not cleared
SXR DCO signed off by Nola Donato nola.donato@samsung.com
