### PR TITLE
Fix plane's scaling issue

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCorePlane.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCorePlane.java
@@ -15,7 +15,7 @@
 
 package com.samsungxr.mixedreality.arcore;
 
-import org.joml.Matrix4f;
+import android.opengl.Matrix;
 import android.support.annotation.NonNull;
 
 import com.google.ar.core.Plane;
@@ -127,10 +127,10 @@ class ARCorePlane extends SXRPlane {
             float w = getWidth();
             float h = getHeight();
             mPose.update(mARPlane.getCenterPose(), scale);
-            Matrix4f m = new Matrix4f();
-            m.set(mPose.getPoseMatrix());
-            m.scaleLocal(w * 0.95f, h * 0.95f, 1.0f);
-            owner.getTransform().setModelMatrix(m);
+
+            Matrix.scaleM(mPose.getPoseMatrix(), 0, w * 0.95f, 1.0f, h * 0.95f);
+
+            owner.getTransform().setModelMatrix(mPose.getPoseMatrix());
         }
     }
     


### PR DESCRIPTION
It looks the current code is scaling the position of detected plane by the plane's dimensions.
Fixing this issue.

SXR-DCO-1.0-Signed-off-by: Ragner Magalhaes <ragner.n@samsung.com>