### PR TITLE
Fix crash in Texture dtor

### DIFF
--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrControllerReader.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrControllerReader.java
@@ -1,5 +1,7 @@
 package com.samsungxr;
 
+import android.view.KeyEvent;
+
 import com.samsungxr.io.SXRGearCursorController;
 
 import java.nio.ByteBuffer;
@@ -11,13 +13,19 @@ final class OvrControllerReader extends SXRGearCursorController.ControllerReader
 
     private FloatBuffer readbackBuffer;
     private final long mPtr;
+    private final SXRApplication mApplication;
+    private final SXREventListeners.ApplicationEvents mApplicationEvents;
 
-    OvrControllerReader(long ptrActivityNative) {
+    OvrControllerReader(SXRApplication application, long ptrActivityNative) {
         ByteBuffer readbackBufferB = ByteBuffer.allocateDirect(DATA_SIZE * BYTE_TO_FLOAT);
         readbackBufferB.order(ByteOrder.nativeOrder());
         readbackBuffer = readbackBufferB.asFloatBuffer();
         mPtr = OvrNativeGearController.ctor(readbackBufferB);
         OvrNativeGearController.nativeInitializeGearController(ptrActivityNative, mPtr);
+
+        mApplication = application;
+        mApplicationEvents = new ApplicationEvents(application);
+        mApplication.getEventReceiver().addListener(mApplicationEvents);
     }
 
     @Override
@@ -47,12 +55,28 @@ final class OvrControllerReader extends SXRGearCursorController.ControllerReader
 
     @Override
     protected void finalize() throws Throwable {
+        mApplication.getEventReceiver().removeListener(mApplicationEvents);
         try {
             OvrNativeGearController.delete(mPtr);
         } finally {
             super.finalize();
         }
     }
+
+    private static final class ApplicationEvents extends SXREventListeners.ApplicationEvents {
+        private final SXRApplication mApplication;
+
+        public ApplicationEvents(final SXRApplication application) {
+            mApplication = application;
+        }
+
+        @Override
+        public void dispatchKeyEvent(final KeyEvent event) {
+            if (KeyEvent.KEYCODE_BACK == event.getKeyCode()) {
+                mApplication.getActivity().dispatchKeyEvent(event);
+            }
+        }
+    };
 
     private static final int INDEX_CONNECTED = 0;
     private static final int INDEX_HANDEDNESS = 1;

--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrViewManager.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrViewManager.java
@@ -135,7 +135,7 @@ class OvrViewManager extends SXRViewManager {
         mStatsLine.addColumn(mTracerDrawEyes2.getStatColumn());
         mStatsLine.addColumn(mTracerAfterDrawEyes.getStatColumn());
 
-        mControllerReader = new OvrControllerReader(mApplication.getActivityNative().getNative());
+        mControllerReader = new OvrControllerReader(application, mApplication.getActivityNative().getNative());
     }
 
     /**

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/io/SXRGearCursorController.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/io/SXRGearCursorController.java
@@ -22,19 +22,20 @@ import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
+import com.samsungxr.IApplicationEvents;
 import com.samsungxr.SXRApplication;
 import com.samsungxr.SXRContext;
 import com.samsungxr.SXREventManager;
 import com.samsungxr.SXREventReceiver;
 import com.samsungxr.SXRImportSettings;
 import com.samsungxr.SXRMaterial;
+import com.samsungxr.SXRNode;
 import com.samsungxr.SXRPicker;
 import com.samsungxr.SXRRenderData;
 import com.samsungxr.SXRScene;
-import com.samsungxr.SXRNode;
-import com.samsungxr.IApplicationEvents;
 import com.samsungxr.nodes.SXRLineNode;
 import com.samsungxr.utility.Log;
+
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -422,7 +423,7 @@ public final class SXRGearCursorController extends SXRCursorController
             try {
                 mControllerReader.getEvents(controllerID, mControllerEvents);
             } catch (final RuntimeException exc) {
-                Log.i(TAG, "getEvents threw: " + exc.toString());
+                Log.e(TAG, "getEvents threw: " + exc.toString());
                 exc.printStackTrace();
             }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/image.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/image.h
@@ -64,20 +64,20 @@ public:
 
     Image() :
             HybridObject(), mState(UNINITIALIZED), mType(NONE), mFormat(0), mIsCompressed(false),
-            mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
+            mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0),
             mLevels(0)
     {
     }
 
     explicit Image(ImageType type, int format) :
             HybridObject(), mState(UNINITIALIZED), mType(type), mFormat(format),mIsCompressed(false),
-            mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0), mUpdateLock(),
+            mXOffset(0), mYOffset(0), mWidth(0), mHeight(0), mDepth(1), mImageSize(0),
             mLevels(0)
     {
     }
 
     explicit Image(ImageType type, short width, short height, int imagesize, int format, short levels) :
-            HybridObject(), mType(type), mState(UNINITIALIZED), mUpdateLock(), mIsCompressed(false),
+            HybridObject(), mType(type), mState(UNINITIALIZED), mIsCompressed(false),
             mXOffset(0), mYOffset(0), mWidth(width), mHeight(height), mDepth(1), mImageSize(imagesize),
             mFormat(format), mLevels(levels)
     {

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/textures/texture.cpp
@@ -37,10 +37,6 @@ Texture::Texture(int type)
 
 Texture::~Texture()
 {
-    if (mJava)
-    {
-        clearData(getCurrentEnv(mJava));
-    }
 }
 
 bool Texture::isReady()
@@ -62,7 +58,6 @@ void Texture::clearData(JNIEnv* env)
     {
         image->clear(env);
     }
-    LOGV("Texture::clearImage %p", this);
 }
 
 void Texture::setImage(Image* image)
@@ -87,7 +82,6 @@ void Texture::setImage(JNIEnv* env, Image* image)
     {
         image->texParamsChanged(getTexParams());
     }
-    LOGV("Texture::setImage %p", this);
 }
 
 void Texture::updateTextureParameters(const int* texture_parameters, int n)


### PR DESCRIPTION
Fix back key handling in Oculus GO

Texture dtor crash reproducible often enough on Oculus GO with sxr-controller.

Back key special cased since when there is a controller events emulation is turned off (no automatic back key propagation to the activity).

Issue: https://github.com/sxrsdk/sxrsdk/issues/82

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>