### PR TITLE
Ensure event emulation is off when the controller is connected

### DIFF
--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrControllerReader.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrControllerReader.java
@@ -72,7 +72,7 @@ final class OvrControllerReader extends SXRGearCursorController.ControllerReader
 
         @Override
         public void dispatchKeyEvent(final KeyEvent event) {
-            if (KeyEvent.KEYCODE_BACK == event.getKeyCode() && KeyEvent.ACTION_DOWN == event.getAction()) {
+            if (KeyEvent.KEYCODE_BACK == event.getKeyCode()) {
                 mApplication.getActivity().dispatchKeyEvent(event);
             }
         }

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -379,6 +379,9 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
                 frameBuffer_[eye].destroy();
             }
 
+            if (nullptr != gearController) {
+                gearController->reset();
+            }
             vrapi_LeaveVrMode(oculusMobile_);
             oculusMobile_ = nullptr;
         } else {

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_gear_controller.cpp
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_gear_controller.cpp
@@ -16,6 +16,10 @@
 
 #include "ovr_gear_controller.h"
 
+#include "glm/gtx/quaternion.hpp"
+#include "util/sxr_log.h"
+
+
 namespace sxr {
 
     bool GearController::findConnectedGearController() {
@@ -24,17 +28,16 @@ namespace sxr {
         for (uint32_t deviceIndex = 0;; deviceIndex++) {
             ovrInputCapabilityHeader curCaps;
 
-            if (vrapi_EnumerateInputDevices(ovrMobile_, deviceIndex, &curCaps) < 0) {
+            if (vrapi_EnumerateInputDevices(mOvrMobile, deviceIndex, &curCaps) < 0) {
                 break;
             }
             switch (curCaps.Type) {
                 case ovrControllerType_TrackedRemote:
                     if (!foundRemote) {
                         foundRemote = true;
-                        if (RemoteDeviceID != curCaps.DeviceID) {
-                            onControllerDisconnected(RemoteDeviceID);
-                            RemoteDeviceID = curCaps.DeviceID;
-                            onControllerConnected(RemoteDeviceID);
+                        if (mRemoteDeviceId != curCaps.DeviceID) {
+                            mRemoteDeviceId = curCaps.DeviceID;
+                            onControllerConnected(mRemoteDeviceId);
                         }
                     }
                     break;
@@ -43,9 +46,8 @@ namespace sxr {
             }
         }
 
-        if (!foundRemote && RemoteDeviceID != ovrDeviceIdType_Invalid) {
-            onControllerDisconnected(RemoteDeviceID);
-            RemoteDeviceID = ovrDeviceIdType_Invalid;
+        if (!foundRemote && mRemoteDeviceId != ovrDeviceIdType_Invalid) {
+            mRemoteDeviceId = ovrDeviceIdType_Invalid;
             return false;
         }
 
@@ -56,59 +58,64 @@ namespace sxr {
         ovrInputTrackedRemoteCapabilities remoteCapabilities;
         remoteCapabilities.Header.Type = ovrControllerType_TrackedRemote;
         remoteCapabilities.Header.DeviceID = deviceID;
-        ovrResult result = vrapi_GetInputDeviceCapabilities(ovrMobile_, &remoteCapabilities.Header);
+        ovrResult result = vrapi_GetInputDeviceCapabilities(mOvrMobile, &remoteCapabilities.Header);
         if (result == ovrSuccess) {
             handedness = (remoteCapabilities.ControllerCapabilities & ovrControllerCaps_LeftHand
                          ) ? 0 : 1;
 
             ovrInputStateTrackedRemote remoteInputState;
             remoteInputState.Header.ControllerType = ovrControllerType_TrackedRemote;
-            result = vrapi_GetCurrentInputState(ovrMobile_, RemoteDeviceID, &remoteInputState
+            result = vrapi_GetCurrentInputState(mOvrMobile, mRemoteDeviceId, &remoteInputState
                     .Header);
         }
-        vrapi_SetRemoteEmulation(ovrMobile_, false);
+        vrapi_SetRemoteEmulation(mOvrMobile, false);
     }
-
-    void GearController::onControllerDisconnected(const ovrDeviceID deviceID) {
-        // not used at the moment
-    }
-
 
     void GearController::onFrame(double predictedDisplayTime) {
         ovrTracking tracking;
-        if (RemoteDeviceID != ovrDeviceIdType_Invalid) {
-            orientationTrackingReadbackBuffer[0] = CONNECTED;
+        if (mRemoteDeviceId != ovrDeviceIdType_Invalid) {
+            mOrientationTrackingReadbackBuffer[0] = CONNECTED;
 
-            orientationTrackingReadbackBuffer[1] = handedness;
-            ovrResult result = vrapi_GetInputTrackingState(ovrMobile_, RemoteDeviceID,
+            mOrientationTrackingReadbackBuffer[1] = handedness;
+            ovrResult result = vrapi_GetInputTrackingState(mOvrMobile, mRemoteDeviceId,
                                                            predictedDisplayTime, &tracking);
-
+            if (ovrSuccess != result) {
+                LOGW("GearController::onFrame: vrapi_GetInputTrackingState failed with %d", result);
+                return;
+            }
             ovrQuatf orientation = tracking.HeadPose.Pose.Orientation;
             const glm::quat tmp(orientation.w, orientation.x, orientation.y, orientation.z);
             const glm::quat quat = glm::conjugate(glm::inverse(tmp));
-            orientationTrackingReadbackBuffer[6] = quat.w;
-            orientationTrackingReadbackBuffer[7] = quat.x;
-            orientationTrackingReadbackBuffer[8] = quat.y;
-            orientationTrackingReadbackBuffer[9] = quat.z;
+            mOrientationTrackingReadbackBuffer[6] = quat.w;
+            mOrientationTrackingReadbackBuffer[7] = quat.x;
+            mOrientationTrackingReadbackBuffer[8] = quat.y;
+            mOrientationTrackingReadbackBuffer[9] = quat.z;
 
             ovrInputStateTrackedRemote state;
             state.Header.ControllerType = ovrControllerType_TrackedRemote;
-            vrapi_GetCurrentInputState(ovrMobile_, RemoteDeviceID, &state.Header);
+            vrapi_GetCurrentInputState(mOvrMobile, mRemoteDeviceId, &state.Header);
 
-            orientationTrackingReadbackBuffer[2] = state.TrackpadStatus;
+            mOrientationTrackingReadbackBuffer[2] = state.TrackpadStatus;
 
-            orientationTrackingReadbackBuffer[10] = state.Buttons;
-            orientationTrackingReadbackBuffer[11] = state.TrackpadPosition.x;
-            orientationTrackingReadbackBuffer[12] = state.TrackpadPosition.y;
+            if (0x20000001 == state.Buttons) {
+                state.Buttons = ovrButton_Enter;
+            }
+            mOrientationTrackingReadbackBuffer[10] = state.Buttons;
+            mOrientationTrackingReadbackBuffer[11] = state.TrackpadPosition.x;
+            mOrientationTrackingReadbackBuffer[12] = state.TrackpadPosition.y;
 
             ovrVector3f position = tracking.HeadPose.Pose.Position;
-            orientationTrackingReadbackBuffer[3] = position.x;
-            orientationTrackingReadbackBuffer[4] = position.y;
-            orientationTrackingReadbackBuffer[5] = position.z;
+            mOrientationTrackingReadbackBuffer[3] = position.x;
+            mOrientationTrackingReadbackBuffer[4] = position.y;
+            mOrientationTrackingReadbackBuffer[5] = position.z;
 
         } else {
             // set disconnected
-            orientationTrackingReadbackBuffer[0] = DISCONNECTED;
+            mOrientationTrackingReadbackBuffer[0] = DISCONNECTED;
         }
+    }
+
+    void GearController::reset() {
+        mRemoteDeviceId = ovrDeviceIdType_Invalid;
     }
 }

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_gear_controller.h
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_gear_controller.h
@@ -18,41 +18,37 @@
 #define FRAMEWORK_OVR_GEAR_CONTROLLER_H
 
 #include "VrApi_Input.h"
-#include "glm/glm.hpp"
-#include "glm/gtx/quaternion.hpp"
-#include "util/sxr_log.h"
 
 namespace sxr {
     class GearController {
 
     private:
-        ovrDeviceID RemoteDeviceID;
-        ovrMobile *ovrMobile_;
-        float *orientationTrackingReadbackBuffer;
+        ovrDeviceID mRemoteDeviceId = ovrDeviceIdType_Invalid;
+        ovrMobile *mOvrMobile;
+        float *mOrientationTrackingReadbackBuffer;
         static const int CONNECTED = 1;
         static const int DISCONNECTED = 0;
 
     public :
 
         GearController(float *orientationTrackingReadbackBuffer) {
-            this->orientationTrackingReadbackBuffer = orientationTrackingReadbackBuffer;
+            this->mOrientationTrackingReadbackBuffer = orientationTrackingReadbackBuffer;
         }
 
 
         void setOvrMobile(ovrMobile *ovrMobile) {
-            this->ovrMobile_ = ovrMobile;
+            this->mOvrMobile = ovrMobile;
         }
 
         bool findConnectedGearController();
 
         void onControllerConnected(ovrDeviceID const deviceID);
 
-        void onControllerDisconnected(ovrDeviceID const disconnectedDeviceID);
-
         void onFrame(double predictedDisplayTime);
 
         int handedness;
 
+        void reset();
     };
 }
 #endif //FRAMEWORK_OVR_GEAR_CONTROLLER_H


### PR DESCRIPTION
Remap the Oculus GO controller trigger key to Button_Enter

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>