### PR TITLE
Add SXRImportSettings.NO_MORPH, fix SD card path

### DIFF
--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRImportSettings.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRImportSettings.java
@@ -103,9 +103,14 @@ public enum SXRImportSettings {
     /**
      * Do not include textures and omit texture coordinates from meshes
      */
-    NO_TEXTURING(0x8000000);
+    NO_TEXTURING(0x8000000),
 
-    
+    /**
+     * Do not include blend shapes (morphs)
+     */
+    NO_MORPH(0x10000000);
+
+
     private int mValue;
     
     private static EnumSet<SXRImportSettings> recommendedSettings = EnumSet.of(TRIANGULATE, FLIP_UV, JOIN_IDENTICAL_VERTICES,

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
@@ -827,6 +827,7 @@ class  SXRJassimpAdapter
             case NO_ANIMATION:
             case NO_LIGHTING:
             case NO_TEXTURING:
+            case NO_MORPH:
                 return null;
             default:
                 // Unsupported setting
@@ -1104,7 +1105,10 @@ class  SXRJassimpAdapter
             renderData.disableLight();
         }
         sceneObject.attachRenderData(renderData);
-        setMeshMorphComponent(mesh, sceneObject, aiMesh);
+        if (!settings.contains(SXRImportSettings.NO_MORPH))
+        {
+            setMeshMorphComponent(mesh, sceneObject, aiMesh);
+        }
     }
 
     private static final Map<AiTextureType, String> textureMap;

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRResourceVolume.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRResourceVolume.java
@@ -180,6 +180,8 @@ public class SXRResourceVolume {
         gvrContext = context;
         volumeType = SXRResourceVolume.VolumeType.ANDROID_ASSETS;
         defaultPath = filename;
+        String sdcard = Environment.getExternalStorageDirectory().getAbsolutePath();
+
         if (fname.startsWith("sd:"))
         {
             defaultPath = defaultPath.substring(3);
@@ -192,7 +194,7 @@ public class SXRResourceVolume {
             defaultPath = FileNameUtils.getParentDirectory(defaultPath);
             volumeType = SXRResourceVolume.VolumeType.ANDROID_SDCARD;
         }
-        else if (fname.startsWith("/storage/emulated/"))
+        else if (fname.startsWith(sdcard))
         {
             defaultPath = FileNameUtils.getParentDirectory(defaultPath);
             volumeType = SXRResourceVolume.VolumeType.ANDROID_SDCARD;


### PR DESCRIPTION
1. Fix SD card comparison to work in all cases
2. Add NO_MORPH to suppress import of blend shapes

SXR DCO signed off by: Nola Donato nola.donato@samsung.com