### PR TITLE
Support multiple bind poses on a single skeleton

### DIFF
--- a/SXR/Extensions/widgetLib/build.gradle
+++ b/SXR/Extensions/widgetLib/build.gradle
@@ -22,11 +22,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 23
+        targetSdkVersion 26
         multiDexEnabled true
     }
 

--- a/SXR/Extensions/x3d/build.gradle
+++ b/SXR/Extensions/x3d/build.gradle
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/SXR/SDK/maven_upload.gradle
+++ b/SXR/SDK/maven_upload.gradle
@@ -104,12 +104,4 @@ afterEvaluate { project ->
         sign configurations.archives
     }
 
-    task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
-        from android.sourceSets.main.java.sourceFiles
-    }
-
-    artifacts {
-        archives androidSourcesJar
-    }
 }

--- a/SXR/SDK/sxrsdk/build.gradle
+++ b/SXR/SDK/sxrsdk/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 24
+        targetSdkVersion 26
 
         externalNativeBuild {
             ndkBuild {

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRJassimpAdapter.java
@@ -342,16 +342,16 @@ class  SXRJassimpAdapter
         SXRVertexBuffer vbuf = mesh.getVertexBuffer();
         int nverts = vbuf.getVertexCount();
         int n = nverts * MAX_WEIGHTS;
+        int numbones = aiBones.size();
         float[] weights = new float[n];
         int[] indices = new int[n];
-        int[] boneMap = new int[aiBones.size()];
+        int[] boneMap = new int[numbones];
+        float[] bindMatrices = new float[numbones * 16];
         int boneIndex = -1;
         SXRSkin skin = new SXRSkin(mSkeleton);
 
-        // Process bones
         Arrays.fill(weights, 0, n - 1,  0.0f);
         Arrays.fill(indices, 0, n - 1, 0);
-
         /*
          * Accumulate vertex weights and indices for all the bones
          * in this mesh. All vertices have four indices and four weights.
@@ -368,7 +368,9 @@ class  SXRJassimpAdapter
                 continue;
             }
             Log.e("BONE", "%d %s -> %d", boneId, boneName, boneIndex + 1);
+            float[] matrixdata = aiBone.getOffsetMatrix(sWrapperProvider);
             boneMap[++boneIndex] = boneId;
+            System.arraycopy(matrixdata, 0, bindMatrices, boneIndex * 16, 16);
             List<AiBoneWeight> boneWeights = aiBone.getBoneWeights();
             for (AiBoneWeight weight : boneWeights)
             {
@@ -391,6 +393,7 @@ class  SXRJassimpAdapter
             }
         }
         skin.setBoneMap(boneMap);
+        skin.setInverseBindPose(bindMatrices);
         /*
          * Normalize the weights for each vertex.
          * Sum the weights and divide by the sum.
@@ -404,10 +407,7 @@ class  SXRJassimpAdapter
             {
                 int j = (v * MAX_WEIGHTS) + i;
                 t += weights[j];
-                //is += " " + indices[j];
-                //ws += " " + weights[j];
             }
-            //Log.v("BONES", is + ws);
             if (t > 0.000001f)
             {
                 for (int i = 0; i < MAX_WEIGHTS; ++i)
@@ -560,8 +560,8 @@ class  SXRJassimpAdapter
 
             root.forAllDescendants(nodeProcessor);
             mSkeleton = new SXRSkeleton(root, nodeProcessor.getBoneNames());
-            SXRPose bindPose = new SXRPose(mSkeleton);
-            Matrix4f bindPoseMtx = new Matrix4f();
+            SXRPose pose = new SXRPose(mSkeleton);
+            Matrix4f poseMtx = new Matrix4f();
             SXRNode skelRoot = mSkeleton.getOwnerObject().getParent();
             Matrix4f rootMtx = skelRoot.getTransform().getModelMatrix4f();
 
@@ -576,9 +576,9 @@ class  SXRJassimpAdapter
                 {
                     float[] matrixdata = aiBone.getOffsetMatrix(sWrapperProvider);
 
-                    bindPoseMtx.set(matrixdata);
-                    bindPoseMtx.invert();
-                    bindPose.setWorldMatrix(boneId, bindPoseMtx);
+                    poseMtx.set(matrixdata);
+                    poseMtx.invert();
+                    pose.setWorldMatrix(boneId, poseMtx);
                 }
                 else if (bone != null)
                 {
@@ -587,26 +587,26 @@ class  SXRJassimpAdapter
 
                     mtx.invert();
                     rootMtx.mul(mtx, mtx);
-                    bindPose.setWorldMatrix(boneId, mtx);
+                    pose.setWorldMatrix(boneId, mtx);
                     Log.w("BONE", "no bind pose matrix for bone %s", boneName);
                 }
             }
-            mSkeleton.setBindPose(bindPose);
+            mSkeleton.setPose(pose);
         }
     }
 
     private void attachBoneAnimations(SXRSkeletonAnimation skelAnim, Map<String, SXRAnimationChannel> animMap)
     {
-        SXRPose bindPose = mSkeleton.getBindPose();
-        Matrix4f bindPoseMtx = new Matrix4f();
+        SXRPose pose = mSkeleton.getPose();
+        Matrix4f poseMtx = new Matrix4f();
         Vector3f vec = new Vector3f();
         final float EPSILON = 0.00001f;
         String boneName = mSkeleton.getBoneName(0);
         SXRAnimationChannel channel = animMap.get(boneName);
         AiBone aiBone;
 
-        bindPose.getWorldMatrix(0, bindPoseMtx);
-        bindPoseMtx.getScale(vec);
+        pose.getWorldMatrix(0, poseMtx);
+        poseMtx.getScale(vec);
         if (channel != null)
         {
             skelAnim.addChannel(boneName, channel);
@@ -615,7 +615,7 @@ class  SXRJassimpAdapter
              * This is required because of a bug in the FBX importer
              * which does not scale the animations to match the bind pose
              */
-            bindPoseMtx.getScale(vec);
+            poseMtx.getScale(vec);
             float delta = vec.lengthSquared();
             delta = 3.0f - delta;
             if (Math.abs(delta) > EPSILON)

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
@@ -521,7 +521,7 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
                     eventName = "onAvatarLoaded";
                 }
                 mSkeleton.poseFromBones();
-                mSkeleton.updateSkinPose();
+                mSkeleton.updateBonePose();
             }
             else if (mSkeleton != null)
             {

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
@@ -12,9 +12,12 @@ import com.samsungxr.SXRImportSettings;
 import com.samsungxr.SXRNode;
 import com.samsungxr.SXRResourceVolume;
 import com.samsungxr.SXRTexture;
+import com.samsungxr.SXRTransform;
 import com.samsungxr.animation.keyframe.BVHImporter;
 import com.samsungxr.animation.keyframe.SXRSkeletonAnimation;
 import com.samsungxr.utility.Log;
+
+import org.joml.Vector3f;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -466,6 +469,7 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
         List<SXRComponent> skins = modelRoot.getAllComponents(SXRSkin.getComponentType());
         SXRNode srcRootBone = skel.getBone(0);
 
+        mAvatarRoot.addChildObject(modelRoot);
         if (srcRootBone != null)
         {
             int boneIndex = mSkeleton.getBoneIndex(skel.getBoneName(0));
@@ -475,9 +479,11 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
                 SXRNode parent = mSkeleton.getBone(boneIndex);
                 if (parent != null)
                 {
-                    for (int i = 0; i < srcRootBone.getChildrenCount(); ++i)
+                    int n = srcRootBone.getChildrenCount();
+
+                    for (int i = 0; i < n; ++i)
                     {
-                        SXRNode child = srcRootBone.getChildByIndex(i);
+                        SXRNode child = srcRootBone.getChildByIndex(0);
                         srcRootBone.removeChildObject(child);
                         parent.addChildObject(child);
                     }
@@ -486,12 +492,13 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
             }
         }
         mSkeleton.merge(skel);
+        mSkeleton.poseToBones();
+        mSkeleton.updateBonePose();
         for (SXRComponent c : skins)
         {
             SXRSkin skin = (SXRSkin) c;
             skin.setSkeleton(mSkeleton);
         }
-        mAvatarRoot.addChildObject(modelRoot);
     }
 
     protected IAssetEvents mLoadModelHandler = new IAssetEvents()
@@ -511,7 +518,6 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
                 if (mSkeleton != null)
                 {
                     mergeSkeleton(skel, modelRoot);
-                    mAvatarRoot.addChildObject(modelRoot);
                 }
                 else
                 {

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
@@ -466,15 +466,10 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
         List<SXRComponent> skins = modelRoot.getAllComponents(SXRSkin.getComponentType());
         SXRNode srcRootBone = skel.getBone(0);
 
-        mSkeleton.merge(skel);
-        for (SXRComponent c : skins)
-        {
-            SXRSkin skin = (SXRSkin) c;
-            skin.setSkeleton(mSkeleton);
-        }
         if (srcRootBone != null)
         {
             int boneIndex = mSkeleton.getBoneIndex(skel.getBoneName(0));
+
             if (boneIndex >= 0)
             {
                 SXRNode parent = mSkeleton.getBone(boneIndex);
@@ -489,6 +484,12 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
                     srcRootBone.getParent().removeChildObject(srcRootBone);
                 }
             }
+        }
+        mSkeleton.merge(skel);
+        for (SXRComponent c : skins)
+        {
+            SXRSkin skin = (SXRSkin) c;
+            skin.setSkeleton(mSkeleton);
         }
         mAvatarRoot.addChildObject(modelRoot);
     }

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
@@ -469,7 +469,6 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
         List<SXRComponent> skins = modelRoot.getAllComponents(SXRSkin.getComponentType());
         SXRNode srcRootBone = skel.getBone(0);
 
-        mAvatarRoot.addChildObject(modelRoot);
         if (srcRootBone != null)
         {
             int boneIndex = mSkeleton.getBoneIndex(skel.getBoneName(0));
@@ -492,13 +491,12 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
             }
         }
         mSkeleton.merge(skel);
-        mSkeleton.poseToBones();
-        mSkeleton.updateBonePose();
         for (SXRComponent c : skins)
         {
             SXRSkin skin = (SXRSkin) c;
             skin.setSkeleton(mSkeleton);
         }
+        mAvatarRoot.addChildObject(modelRoot);
     }
 
     protected IAssetEvents mLoadModelHandler = new IAssetEvents()
@@ -527,7 +525,6 @@ public class SXRAvatar extends SXRBehavior implements IEventReceiver
                     eventName = "onAvatarLoaded";
                 }
                 mSkeleton.poseFromBones();
-                mSkeleton.updateBonePose();
             }
             else if (mSkeleton != null)
             {

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
@@ -490,6 +490,32 @@ public class SXRPose implements PrettyPrint
     }
 
     /**
+     * Get the local matrices of all the bones in this pose (relative to parent node).
+     * <p>
+     * The local matrix for each bone are copied into the
+     * destination array as vectors in the order of their bone index.
+     * The array must be as large as 16 times the number of bones in the skeleton
+     * (which can be obtained by calling {@link #getNumBones}).
+     * @param dest	destination array to get local matrices.
+     *
+     * @see #getLocalRotation
+     * @see #getLocalMatrix
+     * @see #getLocalPosition
+     */
+    public void	getLocalMatrices(float[] dest)
+    {
+        if (dest.length != mBones.length * 16)
+        {
+            throw new IllegalArgumentException("Destination array is the wrong size");
+        }
+        sync();
+        for (int i = 0; i < mBones.length; ++i)
+        {
+            mBones[i].LocalMatrix.get(dest, i * 16);
+        }
+    }
+
+    /**
      * Set the local matrix for this bone (relative to parent bone).
      * <p>
      * All bones in the skeleton start out at the origin oriented along the bone axis (usually 0,0,1).
@@ -519,7 +545,6 @@ public class SXRPose implements PrettyPrint
         }
         if (sDebug)
         {
-
             Log.d("BONE",
                   "setLocalMatrix: %s %s",
                   mSkeleton.getBoneName(boneindex),
@@ -807,7 +832,6 @@ public class SXRPose implements PrettyPrint
         if (sDebug)
         {
             Log.d("BONE", "invert: %s %s", mSkeleton.getBoneName(0), dstBone.toString());
-
         }
         for (int i = 1; i < numbones; ++i)
         {

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
@@ -305,9 +305,7 @@ public class SXRPose implements PrettyPrint
 
             bone.setWorldRotation(rotations[t], rotations[t + 1], rotations[t + 2], rotations[t + 3]);
             bone.Changed |= WORLD_ROT;
-
             calcLocal(bone, mSkeleton.getParentBoneIndex(i));
-
             if (sDebug)
             {
                 Log.d("BONE", "setWorldRotation: %s %s", mSkeleton.getBoneName(i), bone.toString());
@@ -352,7 +350,7 @@ public class SXRPose implements PrettyPrint
      */
     public void setWorldMatrix(int boneindex, Matrix4f mtx)
     {
-        Bone	  bone = mBones[boneindex];
+        Bone bone = mBones[boneindex];
 
         bone.WorldMatrix.set(mtx);
         if (mSkeleton.getParentBoneIndex(boneindex) >= 0)
@@ -700,7 +698,9 @@ public class SXRPose implements PrettyPrint
         float       tolerance = 3 * EPSILON;
 
         if (numbones != src.getNumBones())
+        {
             return false;
+        }
         sync();
         for (int i = 0; i < numbones; ++i)
         {
@@ -903,7 +903,9 @@ public class SXRPose implements PrettyPrint
             boolean	update;
 
             if (pid < 0)							        // root bone?
+            {
                 continue;
+            }
             update = (mBones[pid].Changed & (WORLD_ROT | LOCAL_ROT)) != 0;
             if (!mSkeleton.isLocked(i))				        // bone not locked?
             {

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
@@ -289,7 +289,6 @@ public class SXRPose implements PrettyPrint
      * @see #setWorldMatrix
      * @see #getWorldRotations
      * @see #setWorldPositions
-     * @see SXRSkeleton#setBoneAxis
      * @see #getNumBones
      */
     public void setWorldRotations(float[] rotations)
@@ -330,7 +329,6 @@ public class SXRPose implements PrettyPrint
      * @see #getWorldRotation
      * @see #getLocalRotation
      * @see #setWorldMatrix
-     * @see SXRSkeleton#setBoneAxis
      */
     public void getWorldMatrix(int boneindex, Matrix4f mtx)
     {
@@ -351,7 +349,6 @@ public class SXRPose implements PrettyPrint
      * @see #setLocalRotation
      * @see #getWorldMatrix
      * @see #getWorldPositions
-     * @see SXRSkeleton#setBoneAxis
      */
     public void setWorldMatrix(int boneindex, Matrix4f mtx)
     {
@@ -392,7 +389,6 @@ public class SXRPose implements PrettyPrint
      * @see #getWorldRotation
      * @see #getWorldMatrix
      * @see #getNumBones
-     * @see SXRSkeleton#setBoneAxis
      */
     public void getWorldRotations(float[] rotations)
     {
@@ -425,7 +421,6 @@ public class SXRPose implements PrettyPrint
      * @see #setWorldRotation
      * @see #setWorldRotations
      * @see #setWorldMatrix
-     * @see SXRSkeleton#setBoneAxis
      */
     public void	getWorldRotation(int boneindex, Quaternionf q)
     {
@@ -484,7 +479,6 @@ public class SXRPose implements PrettyPrint
      *
      * @see #getWorldRotation
      * @see #getLocalRotation
-     * @see SXRSkeleton#setBoneAxis
      */
     public void getLocalMatrix(int boneindex, Matrix4f mtx)
     {
@@ -551,7 +545,6 @@ public class SXRPose implements PrettyPrint
      *					the angles are in the bone's local coordinate system.
      * @see #setLocalRotation
      * @see #getNumBones
-     * @see SXRSkeleton#setBoneAxis
      * @see #setWorldRotations
      * @see #setWorldMatrix
      */
@@ -583,7 +576,6 @@ public class SXRPose implements PrettyPrint
      * @see #setLocalRotation
      * @see #setWorldRotations
      * @see #setWorldMatrix
-     * @see SXRSkeleton#setBoneAxis
      */
     public void getLocalRotation(int boneindex, Quaternionf q)
     {
@@ -610,7 +602,6 @@ public class SXRPose implements PrettyPrint
      * @see #setLocalRotations
      * @see #setWorldRotations
      * @see #setWorldMatrix
-     * @see SXRSkeleton#setBoneAxis
      */
     public boolean setLocalRotation(int boneindex, float x, float y, float z, float w)
     {
@@ -649,7 +640,6 @@ public class SXRPose implements PrettyPrint
      * @see #setLocalRotation
      * @see #setWorldRotations
      * @see #setWorldMatrix
-     * @see SXRSkeleton#setBoneAxis
      */
     public void     getLocalPosition(int boneindex, Vector3f pos)
     {
@@ -805,7 +795,7 @@ public class SXRPose implements PrettyPrint
     public void  inverse(SXRPose src)
     {
         if (getSkeleton() != src.getSkeleton())
-            throw new IllegalArgumentException("SXRPose.copy: input pose is incompatible with this pose");
+            throw new IllegalArgumentException("SXRPose.inverse: input pose is incompatible with this pose");
         src.sync();
         int numbones = getNumBones();
         Bone srcBone = src.mBones[0];
@@ -813,7 +803,7 @@ public class SXRPose implements PrettyPrint
 
         mNeedSync = true;
         srcBone.WorldMatrix.invertAffine(dstBone.WorldMatrix);
-        srcBone.LocalMatrix.set(dstBone.WorldMatrix);
+        dstBone.LocalMatrix.set(dstBone.WorldMatrix);
         if (sDebug)
         {
             Log.d("BONE", "invert: %s %s", mSkeleton.getBoneName(0), dstBone.toString());

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPose.java
@@ -69,11 +69,6 @@ public class SXRPose implements PrettyPrint
     public enum PoseSpace
     {
         /**
-         * world positions and orientations are relative to the bind pose of the skeleton.
-         */
-        BIND_POSE_RELATIVE,
-
-        /**
          * world positions and orientations are relative to the root bone of the skeleton.
          */
         SKELETON,
@@ -160,10 +155,7 @@ public class SXRPose implements PrettyPrint
         Bone bone = mBones[boneindex];
         int boneParent = mSkeleton.getParentBoneIndex(boneindex);
 
-        if ((boneParent >= 0) && ((bone.Changed & LOCAL_ROT) == LOCAL_ROT))
-        {
-            calcWorld(bone, boneParent);
-        }
+        calcWorld(bone, boneParent);
         pos.x = bone.WorldMatrix.m30();
         pos.y = bone.WorldMatrix.m31();
         pos.z = bone.WorldMatrix.m32();
@@ -869,10 +861,7 @@ public class SXRPose implements PrettyPrint
         bone.LocalMatrix.setTranslation(x, y, z);
         for (int i = 0; i < mBones.length; ++i)
         {
-            bone = mBones[i];
-            bone.WorldMatrix.m30(bone.WorldMatrix.m30() + dx);
-            bone.WorldMatrix.m31(bone.WorldMatrix.m31() + dy);
-            bone.WorldMatrix.m32(bone.WorldMatrix.m32() + dz);
+            mBones[i].WorldMatrix.translate(dx, dy, dz);
         }
         if (sDebug)
         {
@@ -967,9 +956,16 @@ public class SXRPose implements PrettyPrint
      */
     protected void		calcWorld(Bone bone, int parentId)
     {
-        getWorldMatrix(parentId, mTempMtxB);   // WorldMatrix (parent) TempMtxB
-        mTempMtxB.mul(bone.LocalMatrix);       // WorldMatrix = WorldMatrix(parent) * LocalMatrix
-        bone.WorldMatrix.set(mTempMtxB);
+        if (parentId >= 0)
+        {
+            getWorldMatrix(parentId, mTempMtxB);   // WorldMatrix (parent) TempMtxB
+            mTempMtxB.mul(bone.LocalMatrix);       // WorldMatrix = WorldMatrix(parent) * LocalMatrix
+            bone.WorldMatrix.set(mTempMtxB);
+        }
+        else
+        {
+            bone.WorldMatrix.set(bone.LocalMatrix);
+        }
      }
 
     /**

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseInterpolator.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseInterpolator.java
@@ -252,8 +252,6 @@ public class SXRPoseInterpolator extends SXRAnimation
         }
         pSkeleton.poseToBones();
         pSkeleton.updateBonePose();
-        pSkeleton.updateSkinPose();
-
     }
 
 

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseInterpolator.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseInterpolator.java
@@ -251,7 +251,6 @@ public class SXRPoseInterpolator extends SXRAnimation
             setPoseScale(i);
         }
         pSkeleton.poseToBones();
-        pSkeleton.updateBonePose();
     }
 
 

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
@@ -157,32 +157,33 @@ public class SXRPoseMapper extends SXRAnimation
             throw new IllegalArgumentException("Source skeleton cannot be null");
         }
         String[] lines = bonemap.split("[\r\n]");
-
-        mBoneMap = new int[mSourceSkeleton.getNumBones()];
-        Arrays.fill(mBoneMap, -1);
-        for (String line : lines)
+        synchronized (mDestSkeleton)
         {
-            String[] words;
+            mBoneMap = new int[mSourceSkeleton.getNumBones()];
+            Arrays.fill(mBoneMap, -1);
+            for (String line : lines)
+            {
+                String[] words;
 
-            line = line.trim();
-            if (line.isEmpty())
-            {
-                continue;
-            }
-            words = line.split("[\t ]");
-            int sourceIndex = mSourceSkeleton.getBoneIndex(words[0]);
-            int destIndex = mDestSkeleton.getBoneIndex(words[1]);
+                line = line.trim();
+                if (line.isEmpty())
+                {
+                    continue;
+                }
+                words = line.split("[\t ]");
+                int sourceIndex = mSourceSkeleton.getBoneIndex(words[0]);
+                int destIndex = mDestSkeleton.getBoneIndex(words[1]);
 
-            if ((sourceIndex >= 0) && (destIndex >= 0))
-            {
-                mBoneMap[sourceIndex] = destIndex;
-                mDestSkeleton.setBoneOptions(destIndex, mDestSkeleton.getBoneOptions(destIndex) | SXRSkeleton.BONE_ANIMATE);
-                Log.w("BONE", "%s %d -> %s %d",
-                      words[0], sourceIndex, words[1], destIndex);
-            }
-            else
-            {
-                Log.w("SXRPoseMapper", "makeBoneMap: cannot find bone " + words[0]);
+                if ((sourceIndex >= 0) && (destIndex >= 0))
+                {
+                    mBoneMap[sourceIndex] = destIndex;
+                    mDestSkeleton.setBoneOptions(destIndex, mDestSkeleton.getBoneOptions(destIndex) | SXRSkeleton.BONE_ANIMATE);
+                    Log.w("BONE", "%s %d -> %s %d", words[0], sourceIndex, words[1], destIndex);
+                }
+                else
+                {
+                    Log.w("SXRPoseMapper", "makeBoneMap: cannot find bone " + words[0]);
+                }
             }
         }
     }
@@ -235,13 +236,15 @@ public class SXRPoseMapper extends SXRAnimation
      */
     public void animate(SXRHybridObject target, float time)
     {
-        if ((mSourceSkeleton == null) || !mSourceSkeleton.isEnabled())
+        if ((mSourceSkeleton == null) || !mSourceSkeleton.isEnabled() || !mDestSkeleton.isEnabled())
         {
             return;
         }
-        mapLocalToTarget();
-        mDestSkeleton.poseToBones();
-        mDestSkeleton.updateBonePose();
+        synchronized (mDestSkeleton)
+        {
+            mapLocalToTarget();
+            mDestSkeleton.poseToBones();
+        }
     }
 
 
@@ -316,8 +319,6 @@ public class SXRPoseMapper extends SXRAnimation
         Matrix4f	mtx = new Matrix4f();
 
         srcpose.sync();
-        srcpose.getWorldPosition(0, v);
-        dstpose.setPosition(v.x, v.y, v.z);
         for (int i = 0; i < numsrcbones; ++i)
         {
             int	boneindex = mBoneMap[i];

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
@@ -200,8 +200,8 @@ public class SXRPoseMapper extends SXRAnimation
     {
         int numsrcbones = srcskel.getNumBones();
         int[] bonemap = new int[numsrcbones];
-        SXRPose srcPose = srcskel.getBindPose();
-        SXRPose dstPose = dstskel.getBindPose();
+        SXRPose srcPose = srcskel.getPose();
+        SXRPose dstPose = dstskel.getPose();
 
         for (int i = 0; i < numsrcbones; ++i)
         {
@@ -287,43 +287,6 @@ public class SXRPoseMapper extends SXRAnimation
             }
         }
         dstskel.applyPose(mDestPose, SXRSkeleton.ROTATION_ONLY);
-        return true;
-    }
-
-    public boolean mapBindPose()
-    {
-        SXRSkeleton	srcskel = mSourceSkeleton;
-        SXRSkeleton	dstskel = mDestSkeleton;
-        Vector3f v = new Vector3f();
-        Matrix4f mtx = new Matrix4f();
-
-        if ((dstskel == null) || (srcskel == null))
-        {
-            return false;
-        }
-        if (mBoneMap == null)
-        {
-            mBoneMap = makeBoneMap(srcskel, dstskel);
-        }
-        SXRPose     srcpose = srcskel.getPose();
-        SXRPose     dstbindpose = dstskel.getBindPose();
-        int		    numsrcbones = srcskel.getNumBones();
-
-        srcskel.getPosition(v);
-        dstskel.setPosition(v);
-        for (int i = 0; i < numsrcbones; ++i)
-        {
-            int	boneindex = mBoneMap[i];
-
-            if (boneindex >= 0)
-            {
-                dstbindpose.getLocalMatrix(boneindex, mtx);
-                mtx.invert();
-                mtx.mul(srcpose.getBone(i).LocalMatrix);
-                mDestPose.setLocalMatrix(boneindex, mtx);
-            }
-        }
-        dstskel.applyPose(mDestPose, SXRSkeleton.BIND_POSE_RELATIVE);
         return true;
     }
 

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
@@ -176,6 +176,7 @@ public class SXRPoseMapper extends SXRAnimation
             if ((sourceIndex >= 0) && (destIndex >= 0))
             {
                 mBoneMap[sourceIndex] = destIndex;
+                mDestSkeleton.setBoneOptions(destIndex, mDestSkeleton.getBoneOptions(destIndex) | SXRSkeleton.BONE_ANIMATE);
                 Log.w("BONE", "%s %d -> %s %d",
                       words[0], sourceIndex, words[1], destIndex);
             }
@@ -214,6 +215,7 @@ public class SXRPoseMapper extends SXRAnimation
             bonemap[i] = boneindex;
             if (boneindex >= 0)
             {
+                dstskel.setBoneOptions(boneindex, dstskel.getBoneOptions(boneindex) | SXRSkeleton.BONE_ANIMATE);
                 Log.w("BONE", "%s\n%d: %s\n%d: %s",
                         bonename, i, srcPose.getBone(i).toString(),
                         boneindex, dstPose.getBone(boneindex).toString());

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRPoseMapper.java
@@ -242,7 +242,6 @@ public class SXRPoseMapper extends SXRAnimation
         mapLocalToTarget();
         mDestSkeleton.poseToBones();
         mDestSkeleton.updateBonePose();
-        mDestSkeleton.updateSkinPose();
     }
 
 

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRSkeleton.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRSkeleton.java
@@ -821,51 +821,29 @@ public class SXRSkeleton extends SXRComponent implements PrettyPrint
     }
 
     /*
-     * Compute the skinning matrices from the current pose.
+     * Update the C++ skeleton with the current pose.
      * <p>
      * The skin pose is relative to the untransformed mesh.
-     * It will be used to transform the vertices before
+     * The bone pose is relative to the skeleton bone.
+     * The skin pose is used to transform the vertices before
      * overall translate, rotation and scale are performed.
      * It is the current pose relative to the bind pose
      * of the mesh.
      * <p>
      * Each skinned mesh has an associated @{link SXRSkin} component
      * which manages the bones that affect that mesh.
-     * This function updates the GPU skinning matrices each frame.
-     * @see SXRSkin
-     */
-    public void updateSkinPose()
-    {
-        mPose.getWorldMatrices(mPoseMatrices);
-        NativeSkeleton.setWorldPose(getNative(), mPoseMatrices);
-    }
-
-    /*
-     * Compute the skinning matrices from the current pose.
-     * <p>
-     * The skin pose is relative to the untransformed mesh.
-     * It will be used to transform the vertices before
-     * overall translate, rotation and scale are performed.
-     * It is the current pose relative to the bind pose
-     * of the mesh.
-     * <p>
-     * Each skinned mesh has an associated @{link SXRSkin} component
-     * which manages the bones that affect that mesh.
-     * This function updates the GPU skinning matrices each frame.
+     * This skin component maintains the inverse bind pose
+     * of the mesh so it can be multiplied by the world bone pose
+     * to compute the proper skin pose.
+     * This function updates the local and world pose matrices each frame.
      * @see SXRSkin
      */
     public void updateBonePose()
     {
-        SXRPose pose = getPose();
-        int t = 0;
-
-        for (int i = 0; i < mParentBones.length; ++i)
-        {
-            pose.getLocalMatrix(i, mTempMtx);
-            mTempMtx.get(mPoseMatrices, t);
-            t += 16;
-        }
+        mPose.getLocalMatrices(mPoseMatrices);
         NativeSkeleton.setPose(getNative(), mPoseMatrices);
+        mPose.getWorldMatrices(mPoseMatrices);
+        NativeSkeleton.setWorldPose(getNative(), mPoseMatrices);
     }
 
     /**

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRSkin.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRSkin.java
@@ -109,6 +109,11 @@ public class SXRSkin extends SXRComponent implements PrettyPrint
         }
     }
 
+    public void setInverseBindPose(float[] matrices)
+    {
+        NativeSkin.setInverseBindPose(getNative(), matrices);
+    }
+
     @Override
     public void prettyPrint(StringBuffer sb, int indent)
     {
@@ -127,4 +132,5 @@ class NativeSkin
     static native long getComponentType();
     static native boolean setBoneMap(long object, int[] boneMap);
     static native void setSkeleton(long object, long skel);
+    static native void setInverseBindPose(long object, float[] matrices);
 }

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/BVHImporter.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/BVHImporter.java
@@ -137,6 +137,7 @@ public class BVHImporter
         @Override
         public void start(SXRSkeleton skel)
         {
+            mBindPose = skel.getPose();
             mTempQuat1 = new Quaternionf();
             mTempQuat2 = new Quaternionf();
             mPosKey = new float[3];

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/BVHImporter.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/BVHImporter.java
@@ -137,7 +137,6 @@ public class BVHImporter
         @Override
         public void start(SXRSkeleton skel)
         {
-            mBindPose = skel.getBindPose();
             mTempQuat1 = new Quaternionf();
             mTempQuat2 = new Quaternionf();
             mPosKey = new float[3];
@@ -434,7 +433,7 @@ public class BVHImporter
             bindpose.setLocalPosition(i, p.x, p.y, p.z);
             skel.setBoneName(i, mBoneNames.get(i));
         }
-        skel.setBindPose(bindpose);
+        skel.setPose(bindpose);
         return skel;
     }
 
@@ -629,7 +628,7 @@ public class BVHImporter
             float[] posKeys = posKeysPerBone.get(boneIndex);
             if (order.length() == 3)
             {
-                mSkeleton.getBindPose().getLocalPosition(boneIndex, pos);
+                mSkeleton.getPose().getLocalPosition(boneIndex, pos);
                 posKeys = new float[]{0, pos.x, pos.y, pos.z};
             }
             channel = mKeyMaker.makeAnimationChannel(bonename, posKeys, rotKeys);

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/SXRSkeletonAnimation.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/SXRSkeletonAnimation.java
@@ -246,7 +246,7 @@ public class SXRSkeletonAnimation extends SXRAnimation implements PrettyPrint {
         {
             SXRAnimationChannel channel = mBoneChannels[i];
             if ((channel != null) &&
-                    (skel.getBoneOptions(i) == SXRSkeleton.BONE_ANIMATE))
+                (skel.getBoneOptions(i) == SXRSkeleton.BONE_ANIMATE))
             {
                 channel.animate(timeInSec, temp);
                 if (rootOffset != null)
@@ -259,9 +259,9 @@ public class SXRSkeletonAnimation extends SXRAnimation implements PrettyPrint {
                 pose.setLocalMatrix(i, temp);
             }
         }
-
      return pose;
     }
+
     @Override
     public void prettyPrint(StringBuffer sb, int indent) {
         sb.append(Log.getSpaces(indent));

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/SXRSkeletonAnimation.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/SXRSkeletonAnimation.java
@@ -233,7 +233,6 @@ public class SXRSkeletonAnimation extends SXRAnimation implements PrettyPrint {
         computePose(timeInSec,pose);
         skel.poseToBones();
         skel.updateBonePose();
-        skel.updateSkinPose();
     }
 
     public SXRPose computePose(float timeInSec, SXRPose pose)

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/SXRSkeletonAnimation.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/keyframe/SXRSkeletonAnimation.java
@@ -230,9 +230,12 @@ public class SXRSkeletonAnimation extends SXRAnimation implements PrettyPrint {
     {
         SXRSkeleton skel = getSkeleton();
         SXRPose pose = skel.getPose();
-        computePose(timeInSec,pose);
-        skel.poseToBones();
-        skel.updateBonePose();
+
+        if (skel.isEnabled())
+        {
+            computePose(timeInSec, pose);
+            skel.poseToBones();
+        }
     }
 
     public SXRPose computePose(float timeInSec, SXRPose pose)

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
@@ -51,6 +51,7 @@ namespace sxr {
             memcpy(boneMatrices, mLocalBoneMatrices, n * sizeof(glm::mat4));
             mWorldBoneMatrices = skinMatrices;
             mLocalBoneMatrices = boneMatrices;
+            mNumBones = numbones;
         }
     }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
@@ -47,8 +47,8 @@ namespace sxr {
         {
             std::lock_guard<std::mutex> lock(mLock);
             memcpy(mBoneParents, boneparents, numbones * sizeof(int));
-            memcpy(skinMatrices, mWorldBoneMatrices, n);
-            memcpy(boneMatrices, mLocalBoneMatrices, n);
+            memcpy(skinMatrices, mWorldBoneMatrices, n * sizeof(glm::mat4));
+            memcpy(boneMatrices, mLocalBoneMatrices, n * sizeof(glm::mat4));
             mWorldBoneMatrices = skinMatrices;
             mLocalBoneMatrices = boneMatrices;
         }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
@@ -25,7 +25,7 @@ namespace sxr {
         delete[] mBoneParents;
     };
 
-    void Skeleton::setBoneParents(int* boneparents, int numbones)
+    void Skeleton::updateBones(int boneparents[], const char* bonenames[], int numbones)
     {
         glm::mat4 *skinMatrices = new glm::mat4[numbones];
         glm::mat4 *boneMatrices = new glm::mat4[numbones];
@@ -52,6 +52,10 @@ namespace sxr {
             mWorldBoneMatrices = skinMatrices;
             mLocalBoneMatrices = boneMatrices;
             mNumBones = numbones;
+            for (int i = 0; i < numbones; ++i)
+            {
+                mBoneNames[i] = bonenames[i];
+            }
         }
     }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.cpp
@@ -27,19 +27,22 @@ namespace sxr {
 
     void Skeleton::setBoneParents(int* boneparents, int numbones)
     {
-        glm::mat4* skinMatrices = new glm::mat4[numbones];
-        glm::mat4* boneMatrices = new glm::mat4[numbones];
+        glm::mat4 *skinMatrices = new glm::mat4[numbones];
+        glm::mat4 *boneMatrices = new glm::mat4[numbones];
         int n = mBoneNames.size();
-        mBoneParents = new int[numbones];
+        if (n != numbones)
+        {
+            mBoneParents = new int[numbones];
 
-        if (n >= numbones)
-        {
-            n = numbones;
-        }
-        else
-        {
-            mBoneNames.reserve(numbones);
-            mBoneNames.resize(numbones);
+            if (n >= numbones)
+            {
+                n = numbones;
+            }
+            else
+            {
+                mBoneNames.reserve(numbones);
+                mBoneNames.resize(numbones);
+            }
         }
         {
             std::lock_guard<std::mutex> lock(mLock);

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.h
@@ -34,8 +34,9 @@ public:
     const char* getBoneName(int boneIndex) const;
     void setPose(const float* input);
     void getPose(float* output);
-    void setSkinPose(const float* input);
-    const glm::mat4* getSkinMatrix(int boneId) const;
+    void setWorldPose(const float* input);
+    const glm::mat4* getLocalBoneMatrix(int boneId) const;
+    const glm::mat4* getWorldBoneMatrix(int boneId) const;
     const int*    getBoneParents() const;
     int getBoneParent(int boneId) const;
     int getBoneIndex(const char* name) const;
@@ -59,8 +60,8 @@ private:
     std::mutex  mLock;
     int         mNumBones;
     int*        mBoneParents;
-    glm::mat4*  mSkinMatrices;
-    glm::mat4*  mBoneMatrices;
+    glm::mat4*  mWorldBoneMatrices;
+    glm::mat4*  mLocalBoneMatrices;
     std::vector<std::string> mBoneNames;
 };
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton.h
@@ -29,7 +29,7 @@ public:
     }
 
     int getNumBones() const { return mNumBones; }
-    void setBoneParents(int* parents, int numbones);
+    void updateBones(int parents[], const char* names[], int numbones);
     void setBoneName(int boneIndex, const char* name);
     const char* getBoneName(int boneIndex) const;
     void setPose(const float* input);
@@ -40,6 +40,7 @@ public:
     const int*    getBoneParents() const;
     int getBoneParent(int boneId) const;
     int getBoneIndex(const char* name) const;
+    std::mutex& getLock() { return mLock; }
 
     int getParentBoneID(int boneId) const
     {

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton_jni.cpp
@@ -19,7 +19,7 @@ extern "C" {
     Java_com_samsungxr_animation_NativeSkeleton_setPose(JNIEnv* env, jobject clz,
                                                         jlong jskel, jfloatArray jmatrices);
     JNIEXPORT jboolean JNICALL
-    Java_com_samsungxr_animation_NativeSkeleton_setSkinPose(JNIEnv* env, jobject clz,
+    Java_com_samsungxr_animation_NativeSkeleton_setWorldPose(JNIEnv* env, jobject clz,
                                                             jlong jskel, jfloatArray jmatrices);
     JNIEXPORT jboolean JNICALL
     Java_com_samsungxr_animation_NativeSkeleton_getPose(JNIEnv* env, jobject clz,
@@ -98,7 +98,7 @@ Java_com_samsungxr_animation_NativeSkeleton_getPose(JNIEnv* env, jobject clz,
 }
 
 JNIEXPORT jboolean JNICALL
-Java_com_samsungxr_animation_NativeSkeleton_setSkinPose(JNIEnv* env, jobject clz,
+Java_com_samsungxr_animation_NativeSkeleton_setWorldPose(JNIEnv* env, jobject clz,
                                                   jlong jskel, jfloatArray jmatrices)
 {
     Skeleton* skel = reinterpret_cast<Skeleton*>(jskel);
@@ -110,7 +110,7 @@ Java_com_samsungxr_animation_NativeSkeleton_setSkinPose(JNIEnv* env, jobject clz
     }
     jfloat* inputMatrices = env->GetFloatArrayElements(jmatrices, JNI_FALSE);
 
-    skel->setSkinPose(inputMatrices);
+    skel->setWorldPose(inputMatrices);
     env->ReleaseFloatArrayElements(jmatrices, inputMatrices, JNI_ABORT);
     return true;
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skeleton_jni.cpp
@@ -38,8 +38,8 @@ extern "C" {
     Java_com_samsungxr_animation_NativeSkeleton_getBoneParents(JNIEnv* env, jobject clz,
                                                                 jlong jskel, jintArray parents);
     JNIEXPORT void JNICALL
-    Java_com_samsungxr_animation_NativeSkeleton_setBoneParents(JNIEnv* env, jobject obj,
-                                                               jlong jskel, jintArray boneparents);
+    Java_com_samsungxr_animation_NativeSkeleton_updateBones(JNIEnv* env, jobject obj,
+                                                            jlong jskel, jintArray boneparents, jobjectArray bonenames);
 
 
 } // extern "C"
@@ -159,15 +159,26 @@ Java_com_samsungxr_animation_NativeSkeleton_getBoneName(JNIEnv* env, jobject clz
 }
 
 JNIEXPORT void JNICALL
-Java_com_samsungxr_animation_NativeSkeleton_setBoneParents(JNIEnv* env, jobject obj,
-                                                           jlong jskel, jintArray jboneparents)
+Java_com_samsungxr_animation_NativeSkeleton_updateBones(JNIEnv* env, jobject obj,
+                                                        jlong jskel, jintArray jboneparents, jobjectArray jbonenames)
 {
     jint numbones = env->GetArrayLength(jboneparents);
     jint* boneParents = env->GetIntArrayElements(jboneparents, JNI_FALSE);
     Skeleton* skel = reinterpret_cast<Skeleton*>(jskel);
-    skel->setBoneParents(boneParents, numbones);
-    env->ReleaseIntArrayElements(jboneparents, boneParents, JNI_ABORT);
+    const char* names[numbones];
 
+    for (int i = 0; i < numbones; ++i)
+    {
+        jstring str = (jstring) env->GetObjectArrayElement(jbonenames, i);
+        names[i] = env->GetStringUTFChars(str, JNI_FALSE);
+    }
+    skel->updateBones(boneParents, names, numbones);
+    for (int i = 0; i < numbones; ++i)
+    {
+        jstring str = (jstring) env->GetObjectArrayElement(jbonenames, i);
+        env->ReleaseStringUTFChars(str, names[i]);
+    }
+    env->ReleaseIntArrayElements(jboneparents, boneParents, JNI_ABORT);
 }
 
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skin.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skin.h
@@ -27,7 +27,7 @@ public:
 
     void setBoneMap(const int* bonemap, int numBones);
     void setSkeleton(Skeleton* skel);
-
+    void setInverseBindPose(const float* inverseBindPose, int numBones);
     void bindBuffer(Renderer* renderer, Shader* shader);
     bool updateGPU(Renderer* renderer, Shader* shader);
 
@@ -41,6 +41,7 @@ private:
     std::mutex  mLock;
     Skeleton* mSkeleton;
     std::vector<int> mBoneMap;
+    glm::mat4* mInverseBindPose;
     UniformBlock* mBonesBuffer;
 };
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/skin_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/skin_jni.cpp
@@ -22,7 +22,9 @@ extern "C" {
     JNIEXPORT void JNICALL
     Java_com_samsungxr_animation_NativeSkin_setSkeleton(JNIEnv* env, jobject clz,
                                                        jlong jskin, jlong jskel);
-
+    JNIEXPORT jboolean JNICALL
+    Java_com_samsungxr_animation_NativeSkin_setInverseBindPose(JNIEnv* env, jobject clz,
+                                                       jlong jskin, jfloatArray jmatrices);
 
 } // extern "C"
 
@@ -62,4 +64,15 @@ Java_com_samsungxr_animation_NativeSkin_setSkeleton(JNIEnv* env, jobject clz,
     skin->setSkeleton(skel);
 }
 
+JNIEXPORT jboolean JNICALL
+Java_com_samsungxr_animation_NativeSkin_setInverseBindPose(JNIEnv* env, jobject clz,
+                                                           jlong jskin, jfloatArray jmatrices)
+{
+    Skin* skin = reinterpret_cast<Skin*>(jskin);
+    int n = env->GetArrayLength(jmatrices) * sizeof(float) / sizeof(glm::mat4);
+    jfloat* matrices = env->GetFloatArrayElements(jmatrices, JNI_FALSE);
+    skin->setInverseBindPose(matrices, n);
+    env->ReleaseFloatArrayElements(jmatrices, matrices, JNI_ABORT);
+    return true;
+}
 } // namespace sxr


### PR DESCRIPTION
The bind pose that used to be kept in the skeleton is now kept in the SXRSkin component associated with the mesh. This allows the same skeleton to be used with multiple meshes with different bind poses.

1. Removed SXRSkeleton.getBindPose, SXRSkeleton.setBindPose
2. Added SXRSkin.setInverseBindPose to set the bind pose for the skin
3. Modified asset loader to use new APIs
4. Made Java SXRSkeleton ande  C++ Skeleton more thread-safe by locking around updates
5. SXRPoseMapper will not animate if either skeleton is disabled

SXR DCO signed off by: Nola Donato nola.donato@samsung.com