### PR TITLE
MixedReality: set plane finding mode

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibrarySession.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibrarySession.java
@@ -69,6 +69,7 @@ import com.samsungxr.mixedreality.SXRAnchor;
 import com.samsungxr.mixedreality.SXRHitResult;
 import com.samsungxr.mixedreality.SXRLightEstimate;
 import com.samsungxr.mixedreality.SXRMarker;
+import com.samsungxr.mixedreality.SXRMixedReality;
 import com.samsungxr.mixedreality.SXRPlane;
 import com.samsungxr.mixedreality.SXRPointCloud;
 
@@ -300,6 +301,11 @@ public class CVLibrarySession implements IMixedReality, SXRDrawFrameListener
     @Override
     public SXRPointCloud acquirePointCloud() {
         return null;
+    }
+
+    @Override
+    public void setPlaneFindingMode(SXRMixedReality.PlaneFindingMode mode) {
+
     }
 
     private Vector3f configDisplayGeometry(SXRCameraRig cameraRig)

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/IMixedReality.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/IMixedReality.java
@@ -186,7 +186,6 @@ public interface IMixedReality extends IEventReceiver
 
     float[] makeInterpolated(float[] poseA, float[] poseB, float t);
 
-
     /**
      * Acquires the current set of estimated 3d points
      * attached to real-world geometry.
@@ -194,5 +193,12 @@ public interface IMixedReality extends IEventReceiver
      * @return SXRPointCloud with points info
      */
     SXRPointCloud acquirePointCloud();
+
+    /**
+     * Set the behavior of the plane detection subsystem.
+     *
+     * @param mode The mode to find planes (see {@link SXRMixedReality.PlaneFindingMode})
+     */
+    void setPlaneFindingMode(SXRMixedReality.PlaneFindingMode mode);
 
 }

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/MRCommon.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/MRCommon.java
@@ -143,6 +143,11 @@ public abstract class MRCommon implements IMixedReality
         return onAcquirePointCloud();
     }
 
+    @Override
+    public void setPlaneFindingMode(SXRMixedReality.PlaneFindingMode mode) {
+        onSetPlaneFindingMode(mode);
+    }
+
     protected abstract void onResume();
 
     protected abstract void onPause();
@@ -178,4 +183,6 @@ public abstract class MRCommon implements IMixedReality
     protected abstract float[] onMakeInterpolated(float[] poseA, float[] poseB, float t);
 
     protected abstract SXRPointCloud onAcquirePointCloud();
+
+    protected abstract void onSetPlaneFindingMode(SXRMixedReality.PlaneFindingMode mode);
 }

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRMixedReality.java
@@ -273,6 +273,11 @@ public class SXRMixedReality implements IMixedReality
         return mSession.acquirePointCloud();
     }
 
+    @Override
+    public void setPlaneFindingMode(PlaneFindingMode mode) {
+        mSession.setPlaneFindingMode(mode);
+    }
+
     private class ActivityEventsHandler extends SXREventListeners.ApplicationEvents {
         @Override
         public void onPause() {
@@ -289,4 +294,26 @@ public class SXRMixedReality implements IMixedReality
         ON_RESUME,
         ON_PAUSE
     };
+
+    /**
+     * Designates the mode that the plane subsystem finds a new plane
+     */
+    public enum PlaneFindingMode {
+        /**
+         * Plane detection is disabled
+         */
+        DISABLED,
+        /**
+         * Detection of only horizontal planes is enabled.
+         */
+        HORIZONTAL,
+        /**
+         * Detection of both horizontal and vertical planes is enabled.
+         */
+        HORIZONTAL_AND_VERTICAL,
+        /**
+         * Detection of only vertical planes is enabled.
+         */
+        VERTICAL
+    }
 }

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCoreSession.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCoreSession.java
@@ -58,6 +58,7 @@ import com.samsungxr.mixedreality.SXRAnchor;
 import com.samsungxr.mixedreality.SXRMarker;
 import com.samsungxr.mixedreality.SXRHitResult;
 import com.samsungxr.mixedreality.SXRLightEstimate;
+import com.samsungxr.mixedreality.SXRMixedReality;
 import com.samsungxr.mixedreality.SXRPlane;
 import com.samsungxr.mixedreality.IAnchorEvents;
 import com.samsungxr.mixedreality.IPlaneEvents;
@@ -570,6 +571,29 @@ public class ARCoreSession extends MRCommon {
         pointCloud.setARPointCloud(mLastARFrame.acquirePointCloud());
 
         return pointCloud;
+    }
+
+    @Override
+    protected void onSetPlaneFindingMode(SXRMixedReality.PlaneFindingMode mode) {
+        if (mConfig == null) {
+            return;
+        }
+
+        switch (mode) {
+            case HORIZONTAL:
+                mConfig.setPlaneFindingMode(Config.PlaneFindingMode.HORIZONTAL);
+                break;
+            case HORIZONTAL_AND_VERTICAL:
+                mConfig.setPlaneFindingMode(Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL);
+                break;
+            case VERTICAL:
+                mConfig.setPlaneFindingMode(Config.PlaneFindingMode.VERTICAL);
+                break;
+            case DISABLED:
+            default:
+                mConfig.setPlaneFindingMode(Config.PlaneFindingMode.DISABLED);
+        }
+        mSession.configure(mConfig);
     }
 
     private Vector2f convertToDisplayGeometrySpace(float x, float y) {


### PR DESCRIPTION
Add this option to configure how the plane subsystem finds a new plane.
Also, it is possible to disable the plane detection.

SXR-DCO-1.0-Signed-off-by: Afonso Costa <afonso.j@samsung.com>