### PR TITLE
Fix activity lifecycle management of camera for SXRBodyTracker

### DIFF
--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRBodyTracker.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRBodyTracker.java
@@ -72,6 +72,7 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
     protected SXRPose mDestPose;
     protected final int mWidth = 1280;
     protected final int mHeight = 960;
+    protected final int fps = 30;
     protected SXRSkeleton mTargetSkeleton;
     protected SXRCameraNode mCameraOwner;
     protected byte[] mImageData = null;
@@ -163,9 +164,11 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
                 });
 
                 Camera.Parameters params = mCameraOwner.getCameraParameters();
-                params.setPreviewSize(1280,960);
-                params.setPreviewFpsRange(30000, 30000);
-                params.setPreviewFormat(ImageFormat.NV21);
+                if(params != null) {
+                    params.setPreviewSize(mWidth, mHeight);
+                    params.setPreviewFpsRange(fps * 1000, fps * 1000);
+                    params.setPreviewFormat(ImageFormat.NV21);
+                }
                 mCameraOwner.setCameraParameters(params);
 
             } catch (SXRCameraNode.SXRCameraAccessException e) {
@@ -186,9 +189,8 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
     public void onEnable()
     {
         super.onEnable();
-        if (!isRunning() && (mCameraOwner != null))
+        if (!isRunning())
         {
-            mCameraOwner.close();
             onStart();
         }
     }

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRBodyTracker.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRBodyTracker.java
@@ -73,7 +73,6 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
     protected final int mWidth = 1280;
     protected final int mHeight = 960;
     protected SXRSkeleton mTargetSkeleton;
-//    protected Camera mCamera = null;
     protected SXRCameraNode mCameraOwner;
     protected byte[] mImageData = null;
     private boolean mTryOpenCamera = true;
@@ -153,12 +152,9 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
     {
         if (mTryOpenCamera)
         {
-//            mCamera = openCamera();
             try {
                 mCameraOwner = new SXRCameraNode(getSXRContext(), mWidth / 2, mHeight / 2);
-                Camera camera = mCameraOwner.getAndroidCamera();
-
-                camera.setPreviewCallback(new Camera.PreviewCallback()
+                mCameraOwner.setPreviewCallback(new Camera.PreviewCallback()
                 {
                     public void onPreviewFrame(byte[] data, Camera camera)
                     {
@@ -166,13 +162,12 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
                     }
                 });
 
-//                mCameraOwner.setPreviewCallback(new Camera.PreviewCallback()
-//                {
-//                    public void onPreviewFrame(byte[] data, Camera camera)
-//                    {
-//                        setImageData(data);
-//                    }
-//                });
+                Camera.Parameters params = mCameraOwner.getCameraParameters();
+                params.setPreviewSize(1280,960);
+                params.setPreviewFpsRange(30000, 30000);
+                params.setPreviewFormat(ImageFormat.NV21);
+                mCameraOwner.setCameraParameters(params);
+
             } catch (SXRCameraNode.SXRCameraAccessException e) {
                 throw new IllegalAccessException("Cannot access body tracker");
             }
@@ -181,7 +176,6 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
         }
         if (isEnabled())
         {
-//            mCamera.startPreview();
             if (!onStart())
             {
                 throw new IllegalAccessException("Cannot access body tracker");
@@ -335,40 +329,6 @@ public abstract class SXRBodyTracker extends SXRComponent implements IEventRecei
         getSXRContext().getEventManager().sendEvent(this, TrackerEvents.class, "onTrackEnd", this);
     }
 
-    /**
-     * Opens the camera and starts capturing images.
-     * <p>
-     * The default implementation uses <i>ImageFormat.NV21</i>
-     * and tracks at 30fps. It captures 1280 x 960 images.
-     * The width and height is obtained from mWidth and mHeight
-     * so constructors may set this to change the image size.
-     * @return
-     * @throws CameraAccessException
-     * @throws IOException
-     */
-    protected Camera openCamera() throws CameraAccessException, IOException
-    {
-        Camera camera = Camera.open();
-
-        if (camera == null)
-        {
-            throw new CameraAccessException(CameraAccessException.CAMERA_ERROR);
-        }
-        Camera.Parameters params = camera.getParameters();
-
-        params.setPreviewSize(mWidth, mHeight);
-        params.setPreviewFormat(ImageFormat.NV21);
-        params.setPreviewFpsRange(30000, 30000);
-        camera.setParameters(params);
-        camera.setPreviewCallback(new Camera.PreviewCallback()
-          {
-              public void onPreviewFrame(byte[] data, Camera camera)
-              {
-                  setImageData(data);
-              }
-          });
-        return camera;
-    }
 }
 
 class NativeBodyTracker

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRCameraNode.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRCameraNode.java
@@ -17,6 +17,7 @@ package com.samsungxr.nodes;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.graphics.ImageFormat;
 import android.graphics.SurfaceTexture;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
@@ -46,7 +47,7 @@ public class SXRCameraNode extends SXRNode {
     private int fpsMode = -1;
     private boolean isCameraOpen = false;
     private CameraApplicationEvents cameraApplicationEvents;
-
+    private Camera.PreviewCallback callback = null;
     /**
      * Create a {@linkplain SXRNode node} (with arbitrarily
      * complex geometry) that shows live video from one of the device's cameras
@@ -193,9 +194,15 @@ public class SXRCameraNode extends SXRNode {
                 android.util.Log.d(TAG, "Camera not available or is in use");
                 return false;
             }
+            Parameters params = camera.getParameters();
+            params.setPreviewSize(1280,960);
+            camera.setParameters(params);
+
+
             camera.startPreview();
             camera.setPreviewTexture(mSurfaceTexture);
             isCameraOpen = true;
+
         } catch (Exception exception) {
             android.util.Log.d(TAG, "Camera not available or is in use");
             return false;
@@ -209,6 +216,8 @@ public class SXRCameraNode extends SXRNode {
             //nothing to do
             return;
         }
+
+        camera.setPreviewCallback(null);
 
         camera.stopPreview();
         camera.release();
@@ -276,46 +285,57 @@ public class SXRCameraNode extends SXRNode {
                 Log.v(TAG, "VR Mode supported!");
 
                 // set vr mode
-                params.set("vrmode", 1);
+//                params.set("vrmode", 1);
 
                 // true if the apps intend to record videos using
                 // MediaRecorder
-                params.setRecordingHint(true);
+//                params.setRecordingHint(true);
 
                 // set preview size
                 // params.setPreviewSize(640, 480);
 
                 // set fast-fps-mode: 0 for 30fps, 1 for 60 fps,
                 // 2 for 120 fps
-                params.set("fast-fps-mode", fpsMode);
+//                params.set("fast-fps-mode", fpsMode);
 
-                switch (fpsMode) {
-                    case 0: // 30 fps
-                        params.setPreviewFpsRange(30000, 30000);
-                        break;
-                    case 1: // 60 fps
-                        params.setPreviewFpsRange(60000, 60000);
-                        break;
-                    case 2: // 120 fps
-                        params.setPreviewFpsRange(120000, 120000);
-                        break;
-                    default:
-                }
+//                switch (fpsMode) {
+//                    case 0: // 30 fps
+//                        params.setPreviewFpsRange(30000, 30000);
+//                        break;
+//                    case 1: // 60 fps
+//                        params.setPreviewFpsRange(60000, 60000);
+//                        break;
+//                    case 2: // 120 fps
+//                        params.setPreviewFpsRange(120000, 120000);
+//                        break;
+//                    default:
+//                }
 
                 // for auto focus
-                params.set("focus-mode", "continuous-video");
+//                params.set("focus-mode", "continuous-video");
 
-                params.setVideoStabilization(false);
-                if ("true".equalsIgnoreCase(params.get("ois-supported"))) {
-                    params.set("ois", "center");
-                }
-
+//                params.setVideoStabilization(false);
+//                if ("true".equalsIgnoreCase(params.get("ois-supported"))) {
+//                    params.set("ois", "center");
+//                }
+                params.setPreviewFpsRange(30000, 30000);
+                params.setPreviewFormat(ImageFormat.NV21);
                 camera.setParameters(params);
                 cameraSetUpStatus = true;
             }
         }
 
         return cameraSetUpStatus;
+    }
+
+
+    /**
+     *
+     * @return the an Android {@link Camera} being used by this {@link SXRNode}.
+     */
+    public Camera getAndroidCamera()
+    {
+        return camera;
     }
 
     /**

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRCameraNode.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/nodes/SXRCameraNode.java
@@ -17,7 +17,6 @@ package com.samsungxr.nodes;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.graphics.ImageFormat;
 import android.graphics.SurfaceTexture;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
@@ -33,7 +32,6 @@ import com.samsungxr.SXRTexture;
 import com.samsungxr.utility.Log;
 
 import java.io.IOException;
-import java.security.Policy;
 
 /**
  * A {@linkplain SXRNode node} that shows live video from one of
@@ -293,7 +291,7 @@ public class SXRCameraNode extends SXRNode {
 
                 // true if the apps intend to record videos using
                 // MediaRecorder
-//                params.setRecordingHint(true);
+                params.setRecordingHint(true);
 
                 // set preview size
                 // params.setPreviewSize(640, 480);
@@ -332,14 +330,19 @@ public class SXRCameraNode extends SXRNode {
 
 
     /**
+     * Set the preview callback which is invoked for every preview frame.
+     *
      * @param callback the {@link Camera.PreviewCallback} for the Android {@link Camera}.
      */
     public void setPreviewCallback(Camera.PreviewCallback callback)
     {
         previewCallback = callback;
-        camera.stopPreview();
-        camera.setPreviewCallback(callback);
-        camera.startPreview();
+
+        if(camera != null ) {
+            camera.stopPreview();
+            camera.setPreviewCallback(callback);
+            camera.startPreview();
+        }
     }
 
     /**
@@ -355,6 +358,7 @@ public class SXRCameraNode extends SXRNode {
     }
 
     /**
+     * Set the parameters for the android camera held by this node.
      *
      * @param params the {@link Parameters} to set for the Android {@link Camera}
      *               held by this node.


### PR DESCRIPTION
Added public setter and getter functions to SXRCameraNode for the android camera parameters.
Added a public api for adding the preview callback.
Removed camera object from SXRBodyTracker, ownership of camera is now with the SXRCameraNode.

SXR DCO signed off by: Sushant Ojal sushant.o@samsung.com