### PR TITLE
Add Oculus-specific recenterPose

### DIFF
--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrViewManager.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrViewManager.java
@@ -308,10 +308,15 @@ class OvrViewManager extends SXRViewManager {
 
         mRenderBundle.createRenderTargetChain(isMultiview);
     }
-    /*
-     * SXRF APIs
+
+    /**
+     * Reset the Oculus head & controller poses
      */
+    public void recenterPose() {
+        recenterPose(mApplication.getActivityNative().getNative());
+    }
 
     private native long getRenderTextureInfo(long ptr, int index, int eye );
     private native void drawEyes(long ptr);
+    private native void recenterPose(long ptr);
 }

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -400,4 +400,8 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
         LOGD("Activity: usingMultview = %d", use_multiview);
         return use_multiview;
     }
+
+    void SXRActivity::recenterPose() const {
+        vrapi_RecenterPose(oculusMobile_);
+    }
 }

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
@@ -94,6 +94,8 @@ namespace sxr {
         void setGearController(GearController *controller){
             gearController = controller;
         }
+
+        void recenterPose() const;
     };
 
 }

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity_jni.cpp
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity_jni.cpp
@@ -27,8 +27,10 @@ namespace sxr {
         return reinterpret_cast<long>(sxrActivity);
     }
 
-    JNIEXPORT long JNICALL Java_com_samsungxr_OvrViewManager_getRenderTextureInfo(JNIEnv* jni, jclass clazz, jlong jactivity ,  jint index, jint eye){
-        SXRActivity* sxrActivity = reinterpret_cast<SXRActivity*>(jactivity);
+    JNIEXPORT jlong JNICALL
+    Java_com_samsungxr_OvrViewManager_getRenderTextureInfo(JNIEnv *, jobject, jlong jactivity,
+                                                           jint index, jint eye) {
+        SXRActivity *sxrActivity = reinterpret_cast<SXRActivity *>(jactivity);
         return reinterpret_cast<long>(sxrActivity->getRenderTextureInfo(eye, index));
     }
 
@@ -94,7 +96,14 @@ namespace sxr {
         const SXRActivity *activity = reinterpret_cast<SXRActivity*>(appPtr);
         return activity->usingMultiview();
     }
-    
+
+    extern "C"
+    JNIEXPORT void JNICALL
+    Java_com_samsungxr_OvrViewManager_recenterPose__J(JNIEnv*, jobject, jlong ptr) {
+        const SXRActivity *activity = reinterpret_cast<SXRActivity*>(ptr);
+        activity->recenterPose();
+    }
+
     } //extern "C" {
     
 } //namespace sxr


### PR DESCRIPTION
Added only for Oculus, not part of the public API

To call, assuming the app is using the Oculus backend, do this:
```
        try {
            Method m = mGvrContext.getClass().getMethod("recenterPose");
            m.invoke(mGvrContext);
        } catch (final Exception e) {
            e.printStackTrace();
        }
```

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>