### PR TITLE
Expose ARCore's "public Pose getCenterPose ()" api for SXR apps

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryPlane.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibraryPlane.java
@@ -16,6 +16,7 @@
 package com.samsungxr.mixedreality.CVLibrary;
 
 //import com.google.ar.core.Plane;
+import com.google.ar.core.Pose;
 import android.support.annotation.NonNull;
 
 import com.samsungxr.SXRContext;
@@ -48,6 +49,10 @@ class CVLibraryPlane extends SXRPlane {
     public void getCenterPose(@NonNull float[] poseOut)
     {
         System.arraycopy(mPose.getPoseMatrix(), 0, poseOut, 0, 16);
+    }
+
+    public Pose getCenterPose() {
+        return null;
     }
 
     /**

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRPlane.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/SXRPlane.java
@@ -17,6 +17,7 @@ package com.samsungxr.mixedreality;
 
 import android.support.annotation.NonNull;
 
+import com.google.ar.core.Pose;
 import com.samsungxr.SXRBehavior;
 import com.samsungxr.SXRContext;
 
@@ -52,6 +53,13 @@ public abstract class SXRPlane extends SXRBehavior
      * @param poseOut Array to export the pose to.
      */
     public abstract void getCenterPose(@NonNull float[] poseOut);
+
+    /**
+     * Gets the center pose.
+     *
+     * @return the pose of the center of the detected plane.
+     */
+    public abstract Pose getCenterPose();
 
     public Type getPlaneType()
     {

--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCorePlane.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCorePlane.java
@@ -81,6 +81,11 @@ class ARCorePlane extends SXRPlane {
     }
 
     @Override
+    public Pose getCenterPose() {
+        return mARPlane.getCenterPose();
+    }
+
+    @Override
     public float getWidth() {
         return mARPlane.getExtentX();
     }


### PR DESCRIPTION
This is needed to detect the plane normals.

Signed-off-by: Andrei Huziuk <andrei@inizio.io>
Signed-off-by: Moiz Sonasath <m.sonasath@samsung.com>