### PR TITLE
Add support for a cursor layer

### DIFF
--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrVrAppSettings.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrVrAppSettings.java
@@ -30,4 +30,5 @@ final class OvrVrAppSettings extends VrAppSettings {
     }
 
     public final SceneParams sceneParams;
+    public boolean mUseCursorLayer;
 }

--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrVrapiActivityHandler.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrVrapiActivityHandler.java
@@ -375,7 +375,6 @@ final class OvrVrapiActivityHandler implements OvrActivityHandler {
             nativeOnSurfaceChanged(mPtr, mSurfaceView.getHolder().getSurface());
 
             mViewManager.onSurfaceChanged(width, height);
-            mViewManager.createSwapChain();
         }
 
         @Override
@@ -399,7 +398,7 @@ final class OvrVrapiActivityHandler implements OvrActivityHandler {
 
     private static native int nativeInitializeVrApi(long ptr);
 
-    static native int nativeUninitializeVrApi();
+    static native void nativeUninitializeVrApi();
 
     private static final int VRAPI_INITIALIZE_UNKNOWN_ERROR = -1;
 

--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrXMLParser.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrXMLParser.java
@@ -91,37 +91,30 @@ class OvrXMLParser {
                             if (attributeName.equals("showLoadingIcon")) {
                                 settings.setShowLoadingIcon(Boolean
                                         .parseBoolean(xpp.getAttributeValue(i)));
-                            } else if (attributeName
-                                    .equals("useGazeCursorController")) {
+                            } else if (attributeName.equals("useGazeCursorController")) {
                                 settings.setUseGazeCursorController(Boolean
                                         .parseBoolean(xpp.getAttributeValue(i)));
-                            }  else if (attributeName
-                                    .equals("useControllerTypes")) {
+                            }  else if (attributeName.equals("useControllerTypes")) {
                                 parseControllerTypes(settings, xpp.getAttributeValue(i));
-                            } else if (attributeName
-                                    .equals("useAndroidWearTouchpad")) {
+                            } else if (attributeName.equals("useAndroidWearTouchpad")) {
                                 settings.setUseAndroidWearTouchpad(Boolean
                                         .parseBoolean(xpp.getAttributeValue(i)));
-                            } else if (attributeName
-                                    .equals("useSrgbFramebuffer")) {
+                            } else if (attributeName.equals("useSrgbFramebuffer")) {
                                 settings.setUseSrgbFramebuffer(Boolean
                                         .parseBoolean(xpp.getAttributeValue(i)));
-                            } else if (attributeName
-                                    .equals("useProtectedFramebuffer")) {
+                            } else if (attributeName.equals("useProtectedFramebuffer")) {
                                 settings.setUseProtectedFramebuffer(Boolean
                                         .parseBoolean(xpp.getAttributeValue(i)));
-                            } else if (attributeName
-                                    .equals("framebufferPixelsWide")) {
+                            } else if (attributeName.equals("framebufferPixelsWide")) {
                                 settings.setFramebufferPixelsWide(Integer
                                         .parseInt(xpp.getAttributeValue(i)));
-                            } else if (attributeName
-                                    .equals("framebufferPixelsHigh")) {
+                            } else if (attributeName.equals("framebufferPixelsHigh")) {
                                 settings.setFramebufferPixelsHigh(Integer
                                         .parseInt(xpp.getAttributeValue(i)));
-                            } else if (attributeName
-                                    .equals("useMultiview")){                              
-                                settings.setUseMultiview(Boolean.
-                                        parseBoolean(xpp.getAttributeValue(i)));
+                            } else if (attributeName.equals("useMultiview")){
+                                settings.setUseMultiview(Boolean.parseBoolean(xpp.getAttributeValue(i)));
+                            } else if ("useCursorLayer".equals(attributeName)) {
+                                settings.mUseCursorLayer = Boolean.parseBoolean(xpp.getAttributeValue(i));
                             }
                         } else if (tagName.equals("mode-parms")
                                 || "mode-params".equals(tagName)) {

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.cpp
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.cpp
@@ -25,6 +25,9 @@
 #include <VrApi_Types.h>
 #include <engine/renderer/vulkan_renderer.h>
 #include <objects/textures/render_texture.h>
+#include <objects/scene.h>
+#include <objects/components/perspective_camera.h>
+#include <objects/components/render_target.h>
 
 static const char* activityClassName = "android/app/Activity";
 static const char* applicationClassName = "com/samsungxr/SXRApplication";
@@ -44,9 +47,14 @@ SXRActivity::SXRActivity(JNIEnv &env, jobject activity, jobject vrAppSettings) :
         applicationClass_ = GetGlobalClassReference(env, applicationClassName);
 
         jclass viewManagerClass = env.FindClass(viewManagerClassName);
-        onDrawEyeMethodId = GetMethodId(env, viewManagerClass, "onDrawEye", "(IIZ)V");
         onBeforeDrawEyesMethodId = GetMethodId(env, viewManagerClass, "beforeDrawEyes", "()V");
         updateSensoredSceneMethodId = GetMethodId(env, viewManagerClass, "updateSensoredScene", "()Z");
+
+        mCaptureCenterEyeMethod = GetMethodId(env, viewManagerClass, "captureCenterEye", "(IIZ)V");
+        mCaptureLeftEyeMethod = GetMethodId(env, viewManagerClass, "captureLeftEye", "(IIZ)V");
+        mCaptureRightEyeMethod = GetMethodId(env, viewManagerClass, "captureRightEye", "(IIZ)V");
+        mCaptureFinishMethod = GetMethodId(env, viewManagerClass, "captureFinish", "()V");
+        mCapture3DScreenShot= GetMethodId(env, viewManagerClass, "capture3DScreenShot", "(IIZ)V");
 
         mainThreadId_ = gettid();
     }
@@ -127,7 +135,7 @@ RenderTextureInfo *SXRActivity::getRenderTextureInfo(int eye, int index) {
     renderTextureInfo->fboHeight = fbo.getHeight();
     renderTextureInfo->fboWidth = fbo.getWidth();
     renderTextureInfo->multisamples = mMultisamplesConfiguration;
-    renderTextureInfo->useMultiview = use_multiview;
+    renderTextureInfo->useMultiview = gUseMultiview;
     renderTextureInfo->texId = fbo.getColorTexId(index);
     renderTextureInfo->viewport[0] = x;
     renderTextureInfo->viewport[1] = y;
@@ -158,7 +166,10 @@ void SXRActivity::onSurfaceChanged(JNIEnv &env, jobject jsurface) {
             parms.Flags |= VRAPI_MODE_FLAG_RESET_WINDOW_FULLSCREEN;
         }
         parms.Flags |= VRAPI_MODE_FLAG_NATIVE_WINDOW;
-        //@todo consider VRAPI_MODE_FLAG_CREATE_CONTEXT_NO_ERROR as a release-build optimization
+#ifdef NDEBUG
+        //apply first EGL_CONTEXT_OPENGL_NO_ERROR_KHR
+        //parms.Flags |= VRAPI_MODE_FLAG_CREATE_CONTEXT_NO_ERROR;
+#endif
 
         ANativeWindow *nativeWindow = ANativeWindow_fromSurface(&env, jsurface_);
         if (nullptr == nativeWindow) {
@@ -204,9 +215,9 @@ void SXRActivity::onSurfaceChanged(JNIEnv &env, jobject jsurface) {
 
     const char *extensions = (const char *) glGetString(GL_EXTENSIONS);
     if (multiview && std::strstr(extensions, "GL_OVR_multiview2") != NULL) {
-        use_multiview = true;
+        gUseMultiview = true;
     }
-    if (multiview && !use_multiview) {
+    if (multiview && !gUseMultiview) {
         std::string error = "Multiview is not supported by your device";
         LOGE(" Multiview is not supported by your device");
         throw error;
@@ -214,11 +225,19 @@ void SXRActivity::onSurfaceChanged(JNIEnv &env, jobject jsurface) {
 
     clampToBorderSupported_ = nullptr != std::strstr(extensions, "GL_EXT_texture_border_clamp");
 
-    for (int eye = 0; eye < (use_multiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX); eye++) {
+    mUseCursorLayer = configurationHelper_.getUseCursorLayer(env);
+    for (int eye = 0; eye < (gUseMultiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX); eye++) {
         frameBuffer_[eye].create(mColorTextureFormatConfiguration, mWidthConfiguration,
                                  mHeightConfiguration, mMultisamplesConfiguration,
                                  mResolveDepthConfiguration,
                                  mDepthTextureFormatConfiguration);
+
+        if (mUseCursorLayer) {
+            cursorBuffer_[eye].create(mColorTextureFormatConfiguration, mWidthConfiguration / 2,
+                                      mHeightConfiguration / 2, mMultisamplesConfiguration,
+                                      mResolveDepthConfiguration,
+                                      mDepthTextureFormatConfiguration);
+        }
     }
 
     // default viewport same as window size
@@ -227,6 +246,33 @@ void SXRActivity::onSurfaceChanged(JNIEnv &env, jobject jsurface) {
     width = mWidthConfiguration;
     height = mHeightConfiguration;
     configurationHelper_.getSceneViewport(env, x, y, width, height);
+
+    if (mUseCursorLayer) {
+        const int cnt = vrapi_GetTextureSwapChainLength(cursorBuffer_->mColorTextureSwapChain);
+        const int eyeCount = gUseMultiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX;
+        for (int i = 0; i < cnt; ++i) {
+            for (int j = 0; j < eyeCount; ++j) {
+                FrameBufferObject fbo = cursorBuffer_[j];
+
+                RenderTextureInfo renderTextureInfo;
+                renderTextureInfo.fboId = fbo.getRenderBufferFBOId(i);
+                renderTextureInfo.fboHeight = fbo.getHeight();
+                renderTextureInfo.fboWidth = fbo.getWidth();
+                renderTextureInfo.multisamples = mMultisamplesConfiguration;
+                renderTextureInfo.useMultiview = gUseMultiview;
+                renderTextureInfo.texId = fbo.getColorTexId(i);
+                renderTextureInfo.viewport[0] = x;
+                renderTextureInfo.viewport[1] = y;
+                renderTextureInfo.viewport[2] = fbo.getHeight();
+                renderTextureInfo.viewport[3] = fbo.getWidth();
+
+                mCursorRenderTextures[j][i] = Renderer::getInstance()->createRenderTexture(
+                        renderTextureInfo);
+                mCursorRenderTarget[j][i] = Renderer::getInstance()->createRenderTarget(
+                        mCursorRenderTextures[j][i], gUseMultiview);
+            }
+        }
+    }
 
     projectionMatrix_ = ovrMatrix4f_CreateProjectionFov(
             vrapi_GetSystemPropertyFloat(&oculusJavaGlThread_,
@@ -246,7 +292,7 @@ void SXRActivity::onSurfaceChanged(JNIEnv &env, jobject jsurface) {
 }
 
 void SXRActivity::copyVulkanTexture(int texSwapChainIndex, int eye){
-    RenderTarget* renderTarget = gRenderer->getRenderTarget(texSwapChainIndex, use_multiview ? 2 : eye);
+    RenderTarget* renderTarget = gRenderer->getRenderTarget(texSwapChainIndex, gUseMultiview ? 2 : eye);
     reinterpret_cast<VulkanRenderer*>(gRenderer)->renderToOculus(renderTarget);
 
     glBindTexture(GL_TEXTURE_2D,vrapi_GetTextureSwapChainHandle(frameBuffer_[eye].mColorTextureSwapChain, texSwapChainIndex));
@@ -264,14 +310,8 @@ void SXRActivity::copyVulkanTexture(int texSwapChainIndex, int eye){
     reinterpret_cast<VulkanRenderer*>(gRenderer)->unmapRenderToOculus(renderTarget);
 }
 
-void SXRActivity::onDrawFrame(jobject jViewManager) {
-    ovrFrameParms parms = vrapi_DefaultFrameParms(&oculusJavaGlThread_, VRAPI_FRAME_INIT_DEFAULT,
-                                                  vrapi_GetTimeInSeconds(),
-                                                  NULL);
-    parms.FrameIndex = ++frameIndex;
-    parms.SwapInterval = 1;
-    parms.PerformanceParms = oculusPerformanceParms_;
-
+void SXRActivity::onDrawFrame(JNIEnv* env, jobject jViewManager, jobject javaMainScene)
+{
     const double predictedDisplayTime = vrapi_GetPredictedDisplayTime(oculusMobile_, frameIndex);
     const ovrTracking tracking = vrapi_GetPredictedTracking(oculusMobile_, predictedDisplayTime);
 
@@ -279,24 +319,41 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
                                                              tracking.HeadPose.TimeInSeconds);
     updatedTracking.HeadPose.Pose.Position = tracking.HeadPose.Pose.Position;
 
-    for (int eye = 0; eye < VRAPI_FRAME_LAYER_EYE_MAX; eye++) {
-        ovrFrameLayerTexture &eyeTexture = parms.Layers[0].Textures[eye];
+    ovrLayerProjection2 layers[2] = { vrapi_DefaultLayerProjection2(), vrapi_DefaultLayerProjection2() };
 
-        eyeTexture.ColorTextureSwapChain = frameBuffer_[use_multiview ? 0
-                                                                      : eye].mColorTextureSwapChain;
-        eyeTexture.DepthTextureSwapChain = frameBuffer_[use_multiview ? 0
-                                                                      : eye].mDepthTextureSwapChain;
-        eyeTexture.TextureSwapChainIndex = frameBuffer_[use_multiview ? 0
-                                                                      : eye].mTextureSwapChainIndex;
-        eyeTexture.TexCoordsFromTanAngles = texCoordsTanAnglesMatrix_;
+    const int eyeCount = gUseMultiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX;
+    for (int eye = 0; eye < VRAPI_FRAME_LAYER_EYE_MAX; eye++) {
+        auto& eyeLayer = layers[0].Textures[eye];
+
+        eyeLayer.ColorSwapChain = frameBuffer_[gUseMultiview ? 0 : eye].mColorTextureSwapChain;
+        eyeLayer.SwapChainIndex = frameBuffer_[gUseMultiview ? 0 : eye].mTextureSwapChainIndex;
+        eyeLayer.TexCoordsFromTanAngles = texCoordsTanAnglesMatrix_;
         if (CameraRig::CameraRigType::FREEZE != cameraRig_->camera_rig_type()) {
-            eyeTexture.HeadPose = updatedTracking.HeadPose;
+            layers[0].HeadPose = updatedTracking.HeadPose;
+        }
+
+        if (mUseCursorLayer) {
+            auto &cursorLayer = layers[1].Textures[eye];
+            cursorLayer.ColorSwapChain = cursorBuffer_[gUseMultiview ? 0 : eye].mColorTextureSwapChain;
+            cursorLayer.SwapChainIndex = cursorBuffer_[gUseMultiview ? 0 : eye].mTextureSwapChainIndex;
+            cursorLayer.TexCoordsFromTanAngles = texCoordsTanAnglesMatrix_;
+            layers[1].HeadPose = updatedTracking.HeadPose;
         }
     }
 
-    parms.Layers[0].Flags |= VRAPI_FRAME_LAYER_FLAG_CHROMATIC_ABERRATION_CORRECTION;
+    layers[0].Header.Flags |= VRAPI_FRAME_LAYER_FLAG_CHROMATIC_ABERRATION_CORRECTION;
+    layers[0].Header.SrcBlend = VRAPI_FRAME_LAYER_BLEND_ONE;
+    layers[0].Header.DstBlend = VRAPI_FRAME_LAYER_BLEND_ZERO;
+
+    if (mUseCursorLayer) {
+        layers[1].Header.Flags |= VRAPI_FRAME_LAYER_FLAG_CHROMATIC_ABERRATION_CORRECTION;
+        layers[1].Header.Flags |= VRAPI_FRAME_LAYER_FLAG_FIXED_TO_VIEW;
+        layers[1].Header.SrcBlend = VRAPI_FRAME_LAYER_BLEND_SRC_ALPHA;
+        layers[1].Header.DstBlend = VRAPI_FRAME_LAYER_BLEND_ONE_MINUS_SRC_ALPHA;
+    }
+
     if (CameraRig::CameraRigType::FREEZE == cameraRig_->camera_rig_type()) {
-        parms.Layers[0].Flags |= VRAPI_FRAME_LAYER_FLAG_FIXED_TO_VIEW;
+        layers[0].Header.Flags |= VRAPI_FRAME_LAYER_FLAG_FIXED_TO_VIEW;
     } else {
         const ovrQuatf &orientation = updatedTracking.HeadPose.Pose.Orientation;
         const glm::quat tmp(orientation.w, orientation.x, orientation.y, orientation.z);
@@ -312,17 +369,90 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
     }
     oculusJavaGlThread_.Env->CallVoidMethod(jViewManager, onBeforeDrawEyesMethodId);
 
-    // Render the eye images.
-    for (int eye = 0; eye < (use_multiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX); eye++) {
+    Renderer* renderer = Renderer::getInstance();
+    Scene* mainScene = Scene::main_scene();
+
+    ovrSubmitFrameDescription2 parms = {0};
+    parms.FrameIndex = ++frameIndex;
+    parms.SwapInterval = 1;
+    parms.DisplayTime = predictedDisplayTime;
+    parms.LayerCount = 1;
+
+    // Render the eye images; @todo fix this unwieldy loop
+    for (int eye = 0; eye < eyeCount; eye++) {
         int textureSwapChainIndex = frameBuffer_[eye].mTextureSwapChainIndex;
-        oculusJavaGlThread_.Env->CallVoidMethod(jViewManager, onDrawEyeMethodId, eye,
-                                                textureSwapChainIndex, use_multiview);
+        RenderTarget *renderTarget = renderer->getRenderTarget(textureSwapChainIndex, gUseMultiview ? EYE::MULTIVIEW : eye);
+        Camera *centerCamera = static_cast<Camera *>(cameraRig_->center_camera());
+
+        if (0 == eye) {
+            env->CallVoidMethod(jViewManager, mCapture3DScreenShot, eye, textureSwapChainIndex, gUseMultiview);
+
+            renderer->cullFromCamera(mainScene, javaMainScene, centerCamera, mMaterialShaderManager, mRenderDataVector);
+            if (!mUseCursorLayer) {
+                auto& v = mRenderDataVector[Renderer::LAYER_NORMAL];
+                auto& c = mRenderDataVector[Renderer::LAYER_CURSOR];
+                v.insert(std::end(v), std::begin(c), std::end(c));
+                c.clear();
+            } else {
+                renderer->state_sort(mRenderDataVector[Renderer::LAYER_CURSOR]);
+            }
+            renderer->state_sort(mRenderDataVector[Renderer::LAYER_NORMAL]);
+            mainScene->getLights().shadersRebuilt();
+
+            env->CallVoidMethod(jViewManager, mCaptureCenterEyeMethod, eye, textureSwapChainIndex, gUseMultiview);
+
+            Camera *leftCamera = cameraRig_->left_camera();
+            renderTarget->setCamera(leftCamera);
+            renderer->renderRenderTarget(Scene::main_scene(), javaMainScene, renderTarget,
+                                         mMaterialShaderManager,
+                                         mPostEffectRenderTextureA, mPostEffectRenderTextureB,
+                                         &mRenderDataVector[Renderer::LAYER_NORMAL]);
+
+            env->CallVoidMethod(jViewManager, mCaptureLeftEyeMethod, eye, textureSwapChainIndex, gUseMultiview);
+
+        } else if (1 == eye) {
+            Camera *rightCamera = cameraRig_->right_camera();
+            renderTarget->setCamera(rightCamera);
+            renderer->renderRenderTarget(Scene::main_scene(), javaMainScene, renderTarget,
+                                         mMaterialShaderManager,
+                                         mPostEffectRenderTextureA, mPostEffectRenderTextureB,
+                                         &mRenderDataVector[Renderer::LAYER_NORMAL]);
+
+            env->CallVoidMethod(jViewManager, mCaptureRightEyeMethod, eye, textureSwapChainIndex, gUseMultiview);
+            env->CallVoidMethod(jViewManager, mCaptureFinishMethod);
+        }
 
         if (gRenderer->isVulkanInstance()) {
             copyVulkanTexture(textureSwapChainIndex, eye);
         } else {
             endRenderingEye(eye);
-            FrameBufferObject::unbind();
+        }
+
+        if (mUseCursorLayer && mRenderDataVector[Renderer::LAYER_CURSOR].size() > 0) {
+            // cursor texture/layer; assumes dynamic texture - can be optimized for a cursor that never
+            // changes
+            textureSwapChainIndex = cursorBuffer_[eye].mTextureSwapChainIndex;
+            renderTarget = mCursorRenderTarget[eye][textureSwapChainIndex];
+
+            Camera *camera = eye ? cameraRig_->right_camera() : cameraRig_->left_camera();
+            float alphaOld = camera->background_color_a();
+            camera->set_background_color_a(0.0);
+            renderTarget->setCamera(camera);
+            renderer->renderRenderTarget(Scene::main_scene(), javaMainScene,
+                                         renderTarget,
+                                         mMaterialShaderManager,
+                                         mPostEffectRenderTextureA, mPostEffectRenderTextureB,
+                                         &mRenderDataVector[Renderer::LAYER_CURSOR]);
+            camera->set_background_color_a(alphaOld);
+            parms.LayerCount = 2;
+
+            if (gRenderer->isVulkanInstance()) {
+                //cursor layer not supported for vulkan
+            } else {
+                cursorBuffer_[eye].resolve();
+                cursorBuffer_[eye].advance();
+                cursorBuffer_[eye].unbind();
+            }
         }
     }
 
@@ -332,7 +462,17 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
         gearController->onFrame(predictedDisplayTime);
     }
 
-    vrapi_SubmitFrame(oculusMobile_, &parms);
+    const ovrLayerHeader2 *layersToSubmit[] =
+            {
+                    &layers[0].Header,
+                    &layers[1].Header,
+            };
+    parms.Layers = layersToSubmit;
+
+    ovrResult result = vrapi_SubmitFrame2(oculusMobile_, &parms);
+    if (ovrSuccess != result) {
+        FAIL("vrapi_SubmitFrame2 failed with 0x%X", result);
+    }
 }
 
     void SXRActivity::endRenderingEye(const int eye) {
@@ -363,6 +503,7 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
         //per vrAppFw
         frameBuffer_[eye].resolve();
         frameBuffer_[eye].advance();
+        frameBuffer_[eye].unbind();
     }
 
     void SXRActivity::initializeOculusJava(JNIEnv& env, ovrJava& oculusJava) {
@@ -375,8 +516,9 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
         LOGV("SXRActivity::leaveVrMode");
         Renderer::resetInstance();
         if (nullptr != oculusMobile_) {
-            for (int eye = 0; eye < (use_multiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX); eye++) {
+            for (int eye = 0; eye < (gUseMultiview ? 1 : VRAPI_FRAME_LAYER_EYE_MAX); eye++) {
                 frameBuffer_[eye].destroy();
+                cursorBuffer_[eye].destroy();
             }
 
             if (nullptr != gearController) {
@@ -396,12 +538,15 @@ void SXRActivity::onDrawFrame(jobject jViewManager) {
         return vrapi_GetSystemStatusInt(&oculusJavaMainThread_, VRAPI_SYS_STATUS_DOCKED);
     }
 
-    bool SXRActivity::usingMultiview() const {
-        LOGD("Activity: usingMultview = %d", use_multiview);
-        return use_multiview;
-    }
-
-    void SXRActivity::recenterPose() const {
-        vrapi_RecenterPose(oculusMobile_);
-    }
+void SXRActivity::recenterPose() const {
+    vrapi_RecenterPose(oculusMobile_);
 }
+
+void SXRActivity::initialize(sxr::ShaderManager* shaderManager, sxr::RenderTexture* textureA,
+                             sxr::RenderTexture* textureB) {
+    mMaterialShaderManager = shaderManager;
+    mPostEffectRenderTextureA = textureA;
+    mPostEffectRenderTextureB = textureB;
+}
+
+} // namespace sxr

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
@@ -96,6 +96,7 @@ class RenderTarget;
         jmethodID mCaptureRightEyeMethod;
         jmethodID mCaptureFinishMethod;
         jmethodID mCapture3DScreenShot;
+        jmethodID mGetCaptureTargets;
 
     public:
         void onSurfaceCreated(JNIEnv& env);
@@ -118,6 +119,7 @@ class RenderTarget;
 
         void initialize(sxr::ShaderManager *shaderManager, sxr::RenderTexture *textureA,
                     sxr::RenderTexture *textureB);
+
     };
 
 }

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
@@ -17,6 +17,9 @@
 #ifndef ACTIVITY_JNI_H
 #define ACTIVITY_JNI_H
 
+#include <shaders/shader_manager.h>
+#include <objects/textures/render_texture.h>
+#include <engine/renderer/renderer.h>
 #include "ovr_gear_controller.h"
 #include "ovr_framebufferobject.h"
 #include "objects/components/camera.h"
@@ -25,8 +28,10 @@
 #include "VrApi_Types.h"
 
 namespace sxr {
-    class CameraRig;
-    struct RenderTextureInfo;
+
+class CameraRig;
+struct RenderTextureInfo;
+class RenderTarget;
 
     class SXRActivity
     {
@@ -45,7 +50,6 @@ namespace sxr {
         jclass activityClass_ = nullptr;            // must be looked up from main thread or FindClass() will fail
         jclass applicationClass_ = nullptr;
 
-        jmethodID onDrawEyeMethodId = nullptr;
         jmethodID onBeforeDrawEyesMethodId = nullptr;
         jmethodID updateSensoredSceneMethodId = nullptr;
 
@@ -59,6 +63,7 @@ namespace sxr {
         ovrMobile* oculusMobile_ = nullptr;
         long long frameIndex = 1;
         FrameBufferObject frameBuffer_[VRAPI_FRAME_LAYER_EYE_MAX];
+        FrameBufferObject cursorBuffer_[VRAPI_FRAME_LAYER_EYE_MAX];
         ovrMatrix4f projectionMatrix_;
         ovrMatrix4f texCoordsTanAnglesMatrix_;
         ovrPerformanceParms oculusPerformanceParms_;
@@ -77,11 +82,26 @@ namespace sxr {
         GearController *gearController;
         int mainThreadId_ = 0;
 
+        ShaderManager* mMaterialShaderManager = nullptr;
+        RenderTexture* mPostEffectRenderTextureA = nullptr;
+        RenderTexture* mPostEffectRenderTextureB = nullptr;
+        std::vector<RenderData*> mRenderDataVector[Renderer::MAX_LAYERS];
+
+        RenderTexture* mCursorRenderTextures[VRAPI_FRAME_LAYER_EYE_MAX][4] = {0};
+        RenderTarget* mCursorRenderTarget[VRAPI_FRAME_LAYER_EYE_MAX][4] = {0};
+        bool mUseCursorLayer;
+
+        jmethodID mCaptureCenterEyeMethod;
+        jmethodID mCaptureLeftEyeMethod;
+        jmethodID mCaptureRightEyeMethod;
+        jmethodID mCaptureFinishMethod;
+        jmethodID mCapture3DScreenShot;
+
     public:
         void onSurfaceCreated(JNIEnv& env);
         void copyVulkanTexture(int texSwapChainIndex, int eye);
         void onSurfaceChanged(JNIEnv& env, jobject jsurface);
-        void onDrawFrame(jobject jViewManager);
+        void onDrawFrame(JNIEnv* env, jobject jViewManager, jobject javaMainScene);
         int initializeVrApi();
         static void uninitializeVrApi();
         void leaveVrMode();
@@ -89,13 +109,15 @@ namespace sxr {
         void showConfirmQuit();
 
         bool isHmtConnected() const;
-        bool usingMultiview() const;
 
         void setGearController(GearController *controller){
             gearController = controller;
         }
 
         void recenterPose() const;
+
+        void initialize(sxr::ShaderManager *shaderManager, sxr::RenderTexture *textureA,
+                    sxr::RenderTexture *textureB);
     };
 
 }

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity_jni.cpp
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity_jni.cpp
@@ -14,11 +14,12 @@
  */
 
 #include <jni.h>
-#include <engine/renderer/renderer.h>
 #include <objects/textures/render_texture.h>
 #include "ovr_activity.h"
+
 namespace sxr {
-    extern "C" {
+
+extern "C" {
 
     JNIEXPORT long JNICALL Java_com_samsungxr_OvrActivityNative_onCreate(JNIEnv *jni, jclass,
                                                                        jobject activity,
@@ -67,11 +68,11 @@ namespace sxr {
         activity->onSurfaceChanged(*jni, jsurface);
     }
 
-    JNIEXPORT void JNICALL Java_com_samsungxr_OvrViewManager_drawEyes(JNIEnv * jni, jobject jViewManager,
-                                                                    jlong appPtr) {
-        SXRActivity *activity = reinterpret_cast<SXRActivity*>(appPtr);
-        activity->onDrawFrame(jViewManager);
-    }
+JNIEXPORT void JNICALL
+Java_com_samsungxr_OvrViewManager_drawEyes(JNIEnv* env, jobject jViewManager, jlong appPtr, jobject mainScene) {
+    SXRActivity *activity = reinterpret_cast<SXRActivity *>(appPtr);
+    activity->onDrawFrame(env, jViewManager, mainScene);
+}
     
     JNIEXPORT void JNICALL Java_com_samsungxr_OvrVrapiActivityHandler_nativeShowConfirmQuit(JNIEnv * jni, jclass clazz, jlong appPtr) {
         SXRActivity *activity = reinterpret_cast<SXRActivity*>(appPtr);
@@ -82,7 +83,7 @@ namespace sxr {
         SXRActivity *activity = reinterpret_cast<SXRActivity*>(appPtr);
         return activity->initializeVrApi();
     }
-    
+
     JNIEXPORT void JNICALL Java_com_samsungxr_OvrVrapiActivityHandler_nativeUninitializeVrApi(JNIEnv *, jclass) {
         SXRActivity::uninitializeVrApi();
     }
@@ -92,11 +93,6 @@ namespace sxr {
         return activity->isHmtConnected();
     }
     
-    JNIEXPORT jboolean JNICALL Java_com_samsungxr_SXRConfigurationManager_nativeUsingMultiview(JNIEnv* jni, jclass clazz, jlong appPtr) {
-        const SXRActivity *activity = reinterpret_cast<SXRActivity*>(appPtr);
-        return activity->usingMultiview();
-    }
-
     extern "C"
     JNIEXPORT void JNICALL
     Java_com_samsungxr_OvrViewManager_recenterPose__J(JNIEnv*, jobject, jlong ptr) {
@@ -104,6 +100,17 @@ namespace sxr {
         activity->recenterPose();
     }
 
-    } //extern "C" {
+JNIEXPORT void JNICALL
+Java_com_samsungxr_OvrViewManager_initialize(JNIEnv *env, jobject instance, jlong aNative,
+                                             jlong materialShaderManager,
+                                             jlong postEffectRenderTextureA,
+                                             jlong postEffectRenderTextureB) {
+    SXRActivity *activity = reinterpret_cast<SXRActivity*>(aNative);
+    activity->initialize(reinterpret_cast<ShaderManager *>(materialShaderManager),
+                         reinterpret_cast<RenderTexture *>(postEffectRenderTextureA),
+                         reinterpret_cast<RenderTexture *>(postEffectRenderTextureB));
+}
+
+} //extern "C" {
     
 } //namespace sxr

--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_framebufferobject.h
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_framebufferobject.h
@@ -36,15 +36,12 @@ public:
     void advance();
     int getWidth(){ return  mWidth; }
     int getHeight() { return mHeight; }
-    int getSamples() { return mMultisamples; }
     GLuint getColorTexId(int index){   return vrapi_GetTextureSwapChainHandle( mColorTextureSwapChain, index); }
     GLuint getRenderBufferFBOId(int index) { return mRenderFrameBuffers[index]; }
 public:
     int mWidth = 0;
     int mHeight = 0;
-    int mMultisamples = 0;
     int mTextureSwapChainLength = 0;
-    int mDepthTextureSwapChainLength = 0;
     int mTextureSwapChainIndex = 0;
     ovrTextureSwapChain* mColorTextureSwapChain = nullptr;
     ovrTextureSwapChain* mDepthTextureSwapChain = nullptr;

--- a/SXR/SDK/backend_oculus/src/main/jni/util/ovr_configuration_helper.cpp
+++ b/SXR/SDK/backend_oculus/src/main/jni/util/ovr_configuration_helper.cpp
@@ -181,4 +181,9 @@ void ConfigurationHelper::getSceneViewport(JNIEnv& env, int& viewport_x, int& vi
     }
 }
 
+const bool ConfigurationHelper::getUseCursorLayer(JNIEnv &env) {
+    jfieldID fid = env.GetFieldID(vrAppSettingsClass_, "mUseCursorLayer", "Z");
+    return env.GetBooleanField(vrAppSettings_, fid);
+}
+
 }

--- a/SXR/SDK/backend_oculus/src/main/jni/util/ovr_configuration_helper.h
+++ b/SXR/SDK/backend_oculus/src/main/jni/util/ovr_configuration_helper.h
@@ -34,6 +34,9 @@ public:
     void getPerformanceConfiguration(JNIEnv& env, ovrPerformanceParms& parmsOut);
     void getSceneViewport(JNIEnv& env, int& viewport_x, int& viewport_y, int& viewport_width, int& viewport_height);
     void getMultiviewConfiguration(JNIEnv& env, bool& useMultiview);
+
+    const bool getUseCursorLayer(JNIEnv &env);
+
 private:
     JNIEnv& env_;
     jclass vrAppSettingsClass_;

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRConfigurationManager.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRConfigurationManager.java
@@ -163,11 +163,6 @@ abstract class SXRConfigurationManager {
      */
     private static native boolean nativeUsingMultiview(long ptr);
 
-    public boolean usingMultiview()
-    {
-        return nativeUsingMultiview(mApplication.get().getNative());
-    }
-
     private String getHmtModel() {
         return mHeadsetModel;
     }

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderBundle.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderBundle.java
@@ -28,8 +28,8 @@ class SXRRenderBundle {
     protected int  mSampleCount;
     protected int mWidth, mHeight;
     protected SXRRenderTarget[] mLeftEyeRenderTarget = new SXRRenderTarget[3];
-    protected SXRRenderTarget [] mRightEyeRenderTarget = new SXRRenderTarget[3];
-    protected SXRRenderTarget [] mMultiviewRenderTarget = new SXRRenderTarget[3];
+    protected SXRRenderTarget[] mRightEyeRenderTarget = new SXRRenderTarget[3];
+    protected SXRRenderTarget[] mMultiviewRenderTarget = new SXRRenderTarget[3];
 
 
     private SXRRenderTexture mEyeCapturePostEffectRenderTextureA = null;
@@ -59,7 +59,7 @@ class SXRRenderBundle {
         else if(eye == SXRViewManager.EYE.LEFT)
             mLeftEyeRenderTarget[index] = new SXRRenderTarget(renderTexture, mSXRContext.getMainScene());
         else
-            mRightEyeRenderTarget[index] = new SXRRenderTarget(renderTexture, mSXRContext.getMainScene(),mLeftEyeRenderTarget[index]);
+            mRightEyeRenderTarget[index] = new SXRRenderTarget(renderTexture, mSXRContext.getMainScene());
     }
 
 
@@ -75,16 +75,8 @@ class SXRRenderBundle {
             }
 
         }
-        for(int i=0; i< 3; i++){
-            int index = (i+1) % 3;
-            if(use_multiview)
-                mMultiviewRenderTarget[i].attachRenderTarget(mMultiviewRenderTarget[index]);
-            else {
-                mLeftEyeRenderTarget[i].attachRenderTarget(mLeftEyeRenderTarget[index]);
-                mRightEyeRenderTarget[i].attachRenderTarget(mRightEyeRenderTarget[index]);
-            }
-        }
     }
+
     public SXRRenderTarget getEyeCaptureRenderTarget() {
         if(mEyeCaptureRenderTarget == null){
             mEyeCaptureRenderTarget  = new SXRRenderTarget(new SXRRenderTexture(mSXRContext, mWidth, mHeight, mSampleCount), mSXRContext.getMainScene());

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderData.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderData.java
@@ -829,6 +829,22 @@ public final class SXRRenderData extends SXRComponent implements IRenderable, Pr
         NativeRenderData.setStencilTest(getNative(), flag);
         return this;
     }
+
+    public enum LayerType {
+        WorldLocked,
+        HeadLocked
+    }
+
+    /**
+     * Assign this render data to a layer. WorldLocked is the default; HeadLocked is for objects
+     * attached to the camera rig - like HUDs, cursor reticles. HeadLocked objects may not be
+     * subject to reprojection. "May not" because it depends on the backend and the backend adapter
+     * capabilities. HeadLocked objects are supported for the Oculus Mobile SDK.
+     * @param layer
+     */
+    public void setLayer(LayerType layer) {
+        NativeRenderData.setLayer(getNative(), LayerType.HeadLocked == layer ? 1 : 0);
+    }
 }
 
 class NativeRenderData {
@@ -917,4 +933,6 @@ class NativeRenderData {
     static native void setStencilTest(long renderData, boolean flag);
 
     static native void setBindShaderObject(long renderData, SXRRenderData.BindShaderFromNative object);
+
+    static native void setLayer(long aNative, int layer);
 }

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderTarget.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/SXRRenderTarget.java
@@ -28,8 +28,6 @@ package com.samsungxr;
  */
 public class SXRRenderTarget extends SXRBehavior
 {
-
-    protected SXRMaterial mMaterial;
     protected SXRRenderTexture mTexture;
     protected SXRScene  mScene;
     protected SXRCamera mCamera;
@@ -72,14 +70,7 @@ public class SXRRenderTarget extends SXRBehavior
         mCamera = camera;
         NativeRenderTarget.setCamera(getNative(), camera.getNative());
     }
-    public SXRRenderTarget(SXRRenderTexture texture, SXRScene scene, SXRRenderTarget renderTarget)
-    {
-        super(texture.getSXRContext(), NativeRenderTarget.ctor(texture.getNative(), renderTarget.getNative()));
-        setEnable(false);
-        mTexture = texture;
-        mScene = scene;
-        setMainScene(scene);
-    }
+
     public SXRRenderTarget(SXRRenderTexture texture, SXRScene scene, boolean isMultiview)
     {
         super(texture.getSXRContext(), NativeRenderTarget.ctorMultiview(texture.getNative(),isMultiview));
@@ -90,9 +81,7 @@ public class SXRRenderTarget extends SXRBehavior
         setCamera(scene.getMainCameraRig().getCenterCamera());
 
     }
-    public void attachRenderTarget(SXRRenderTarget renderTarget){
-        NativeRenderTarget.attachRenderTarget(getNative(),renderTarget.getNative());
-    }
+
     public void beginRendering(SXRCamera camera){
         NativeRenderTarget.beginRendering(getNative(), camera.getNative());
     }
@@ -159,7 +148,6 @@ class NativeRenderTarget
     static native void endRendering(long rendertarget);
     static native long ctorMultiview(long texture, boolean isMultiview);
     static native void setCamera(long rendertarget, long camera);
-    static native long ctor(long texture, long sourceRendertarget);
     static native void cullFromCamera(long scene, SXRScene javaNode, long renderTarget,long camera, long shader_manager );
     static native void render(long renderTarget, long camera, long shader_manager, long posteffectrenderTextureA, long posteffectRenderTextureB, long scene, SXRScene javaNode);
     static native void setTexture(long rendertarget, long texture);

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/batch_manager.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/batch_manager.cpp
@@ -117,7 +117,7 @@ void BatchManager::renderBatches(RenderState& rstate) {
 
         gRenderer->setRenderStates(renderdata, rstate);
 
-        if(use_multiview){
+        if(gUseMultiview){
            rstate.uniforms.u_view_[0] = rstate.scene->main_camera_rig()->left_camera()->getViewMatrix();
            rstate.uniforms.u_view_[1] = rstate.scene->main_camera_rig()->right_camera()->getViewMatrix();
         }
@@ -144,7 +144,7 @@ void BatchManager::renderBatches(RenderState& rstate) {
 void BatchManager::render_batch(const std::vector<glm::mat4>& model_matrix,
         RenderData* render_data, unsigned int indexCount)
 {
-    if(use_multiview)
+    if(gUseMultiview)
         glDrawElementsInstanced(render_data->draw_mode(),indexCount, GL_UNSIGNED_SHORT, NULL, 2 );
     else
         GL(glDrawElements(render_data->draw_mode(), indexCount, GL_UNSIGNED_SHORT,

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/gl_renderer.h
@@ -76,7 +76,7 @@ public:
     virtual VertexBuffer* createVertexBuffer(const char* descriptor, int vcount);
 
     virtual void renderRenderTarget(Scene*, jobject javaNode, RenderTarget* renderTarget, ShaderManager* shader_manager,
-            RenderTexture* post_effect_render_texture_a, RenderTexture* post_effect_render_texture_b);
+            RenderTexture* post_effect_render_texture_a, RenderTexture* post_effect_render_texture_b, std::vector<RenderData*>* render_data_vector);
     void makeShadowMaps(Scene* scene, jobject javaNode, ShaderManager* shader_manager);
 
     void set_face_culling(int cull_face);
@@ -108,7 +108,7 @@ public:
 private:
     virtual void renderMesh(RenderState& rstate, RenderData* render_data);
     virtual void renderMaterialShader(RenderState& rstate, RenderData* render_data, ShaderData *material, Shader* shader);
-    virtual void occlusion_cull(RenderState& rstate, std::vector<Node*>& nodes, std::vector<RenderData*>* render_data_vector);
+    virtual void occlusion_cull(RenderState& rstate, std::vector<Node*>* nodes, std::vector<RenderData*>* render_data_vector);
     void clearBuffers(const Camera& camera) const;
 
     GLUniformBlock* transform_ubo_[2];

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.cpp
@@ -263,8 +263,11 @@ void VulkanRenderer::renderRenderDataVector(RenderState& rstate,std::vector<Rend
         }
     }
 }
+
 void VulkanRenderer::renderRenderTarget(Scene* scene, jobject javaNode, RenderTarget* renderTarget, ShaderManager* shader_manager,
-                                        RenderTexture* post_effect_render_texture_a, RenderTexture* post_effect_render_texture_b){
+                                        RenderTexture* post_effect_render_texture_a, RenderTexture* post_effect_render_texture_b,
+                                        std::vector<RenderData*>* render_data_vector)
+{
     std::vector<RenderData*> render_data_list;
     Camera* camera = renderTarget->getCamera();
     RenderState rstate = renderTarget->getRenderState();
@@ -281,7 +284,6 @@ void VulkanRenderer::renderRenderTarget(Scene* scene, jobject javaNode, RenderTa
     if(vulkanCore_->isSwapChainPresent())
         rstate.uniforms.u_proj = glm::mat4(1,0,0,0,  0,-1,0,0, 0,0,0.5,0, 0,0,0.5,1) * rstate.uniforms.u_proj;
 
-    std::vector<RenderData*>* render_data_vector = renderTarget->getRenderDataVector();
     LightList& lights = scene->getLights();
 
     int postEffectCount = 0;

--- a/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/engine/renderer/vulkan_renderer.h
@@ -130,7 +130,7 @@ public:
                                  const char* vertexDescriptor, const char* vertexShader,
                                  const char* fragmentShader);
     virtual void renderRenderTarget(Scene*, jobject javaNode, RenderTarget* renderTarget, ShaderManager* shader_manager,
-                                    RenderTexture* post_effect_render_texture_a, RenderTexture* post_effect_render_texture_b);
+                                    RenderTexture* post_effect_render_texture_a, RenderTexture* post_effect_render_texture_b, std::vector<RenderData*>* render_data_vector);
 
     virtual Light* createLight(const char* uniformDescriptor, const char* textureDescriptor);
 
@@ -141,7 +141,7 @@ private:
     VulkanCore* vulkanCore_;
     void renderMesh(RenderState& rstate, RenderData* render_data){}
     void renderMaterialShader(RenderState& rstate, RenderData* render_data, ShaderData *material, Shader*){}
-    virtual void occlusion_cull(RenderState& rstate, std::vector<Node*>& nodes, std::vector<RenderData*>* render_data_vector) {
+    virtual void occlusion_cull(RenderState& rstate, std::vector<Node*>* nodes, std::vector<RenderData*>* render_data_vector) {
         occlusion_cull_init(rstate, nodes, render_data_vector);
 
     }

--- a/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_texture.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/gl/gl_render_texture.cpp
@@ -312,21 +312,19 @@ void GLRenderTexture::beginRendering(Renderer* renderer)
 
 void GLRenderTexture::endRendering(Renderer* renderer)
 {
-    Image* image = getImage();
-    const int width = image->getWidth();
-    const int height = image->getHeight();
-    int fbid = getFrameBufferId();
-
     const bool isFbo = 0 != renderTexture_gl_frame_buffer_->id();
     invalidateFrameBuffer(GL_DRAW_FRAMEBUFFER, isFbo, false, true);
 
     if (renderTexture_gl_resolve_buffer_ && mSampleCount > 1)
     {
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, fbid);
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, getFrameBufferId());
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, renderTexture_gl_resolve_buffer_->id());
-        glBlitFramebuffer(0, 0, width, height,
-                          0, 0, width, height,
-                          GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+        Image* image = getImage();
+        const int width = image->getWidth();
+        const int height = image->getHeight();
+        glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
         invalidateFrameBuffer(GL_READ_FRAMEBUFFER, isFbo, true, false);
     }
 

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.cpp
@@ -350,4 +350,8 @@ void RenderData::setBindShaderObject(JNIEnv* env, jobject bindShaderObject)
     env->GetJavaVM(&javaVm_);
 }
 
+void RenderData::setLayer(int layer) {
+    mLayer = layer;
+}
+
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data.h
@@ -388,6 +388,8 @@ public:
         return *(reinterpret_cast<unsigned short*>(&render_data_flags));
     }
 
+    int layer() { return mLayer; }
+
 private:
     RenderData(RenderData&& render_data) = delete;
     RenderData& operator=(const RenderData& render_data) = delete;
@@ -445,9 +447,13 @@ protected:
     jobject bindShaderObject_ = nullptr;
     JavaVM* javaVm_ = nullptr;
 
+    int mLayer = 0;
+
 public:
     void setStencilTest(bool flag);
     void setBindShaderObject(JNIEnv* env, jobject bindShaderObject);
+
+    void setLayer(int layer);
 };
 
 bool compareRenderDataByOrderShaderDistance(RenderData* i, RenderData* j);

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_data_jni.cpp
@@ -187,6 +187,9 @@ extern "C" {
     JNIEXPORT void JNICALL
     Java_com_samsungxr_NativeRenderData_setBindShaderObject(JNIEnv *env, jclass type, jlong jRenderData,
                                                           jobject bindShaderObject);
+
+    JNIEXPORT void JNICALL
+    Java_com_samsungxr_NativeRenderData_setLayer(JNIEnv *env, jclass type, jlong aNative, jint layer);
 }
 
 
@@ -494,6 +497,12 @@ JNIEXPORT void JNICALL
 Java_com_samsungxr_NativeRenderData_setBindShaderObject(JNIEnv* env, jclass, jlong jRenderData, jobject bindShaderObject) {
     RenderData* rd = reinterpret_cast<RenderData*>(jRenderData);
     rd->setBindShaderObject(env, bindShaderObject);
+}
+
+JNIEXPORT void JNICALL
+Java_com_samsungxr_NativeRenderData_setLayer(JNIEnv *env, jclass type, jlong aNative, jint layer) {
+    RenderData* rd = reinterpret_cast<RenderData*>(aNative);
+    rd->setLayer(layer);
 }
 
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.cpp
@@ -35,8 +35,7 @@ namespace sxr {
  * @param texture RenderTexture to render to
  */
 RenderTarget::RenderTarget(RenderTexture* tex, bool is_multiview)
-: Component(RenderTarget::getComponentType()),mNextRenderTarget(nullptr),
-  mRenderTexture(tex),mRenderDataVector(std::make_shared< std::vector<RenderData*>>())
+    : Component(RenderTarget::getComponentType()), mRenderTexture(tex)
 {
     mRenderState.is_shadow = false;
     mRenderState.shadow_map = nullptr;
@@ -70,7 +69,7 @@ void RenderTarget::endRendering(Renderer *renderer) {
     mRenderTexture->endRendering(renderer);
 }
 RenderTarget::RenderTarget(Scene* scene)
-: Component(RenderTarget::getComponentType()), mNextRenderTarget(nullptr), mRenderTexture(nullptr),mRenderDataVector(std::make_shared< std::vector<RenderData*>>()){
+: Component(RenderTarget::getComponentType()) {
     mRenderState.is_shadow = false;
     mRenderState.shadow_map = nullptr;
     mRenderState.material_override = NULL;
@@ -80,7 +79,8 @@ RenderTarget::RenderTarget(Scene* scene)
 }
 
 RenderTarget::RenderTarget(Scene* scene, int defaultViewportW, int defaultViewportH)
-        : Component(RenderTarget::getComponentType()), mNextRenderTarget(nullptr), mRenderTexture(nullptr),mRenderDataVector(std::make_shared< std::vector<RenderData*>>()){
+        : Component(RenderTarget::getComponentType())
+{
     mRenderState.is_shadow = false;
     mRenderState.shadow_map = nullptr;
     mRenderState.material_override = NULL;
@@ -90,24 +90,13 @@ RenderTarget::RenderTarget(Scene* scene, int defaultViewportW, int defaultViewpo
     mRenderState.viewportHeight = defaultViewportH;
 }
 
-RenderTarget::RenderTarget(RenderTexture* tex, const RenderTarget* source)
-        : Component(RenderTarget::getComponentType()),mNextRenderTarget(nullptr),
-          mRenderTexture(tex), mRenderDataVector(source->mRenderDataVector)
-{
-    mRenderState.is_shadow = false;
-    mRenderState.shadow_map = nullptr;
-    mRenderState.material_override = NULL;
-    mRenderState.is_multiview = false;
-    mRenderState.sampleCount = mRenderTexture->getSampleCount();
-}
 /**
  * Constructs an empty render target without a render texture.
  * This component will not render anything until a RenderTexture
  * is provided.
  */
 RenderTarget::RenderTarget()
-:   Component(RenderTarget::getComponentType()),
-    mRenderTexture(nullptr),mNextRenderTarget(nullptr), mRenderDataVector(std::make_shared< std::vector<RenderData*>>())
+:   Component(RenderTarget::getComponentType())
 {
     mRenderState.is_multiview = false;
     mRenderState.shadow_map = nullptr;
@@ -116,10 +105,10 @@ RenderTarget::RenderTarget()
 }
 
 void RenderTarget::cullFromCamera(Scene* scene, jobject javaNode, Camera* camera, Renderer* renderer, ShaderManager* shader_manager){
-
-    renderer->cullFromCamera(scene, javaNode, camera,shader_manager, mRenderDataVector.get(),mRenderState.is_multiview);
+    renderer->cullFromCamera(scene, javaNode, camera,shader_manager, mRenderDataVector);
     scene->getLights().shadersRebuilt();
-    renderer->state_sort(mRenderDataVector.get());
+    renderer->state_sort(mRenderDataVector[Renderer::LAYER_NORMAL]);
+    renderer->state_sort(mRenderDataVector[Renderer::LAYER_CURSOR]);
 }
 
 RenderTarget::~RenderTarget()

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target.h
@@ -44,15 +44,9 @@ public:
     explicit RenderTarget(RenderTexture*, bool is_multiview);
     explicit RenderTarget(Scene*);
     explicit RenderTarget(Scene*, int defaultViewportW, int defaultViewportH);
-    explicit RenderTarget(RenderTexture*, const RenderTarget* source);
     RenderTarget();
     virtual ~RenderTarget();
-    void attachNextRenderTarget(RenderTarget* renderTarget){
-        mNextRenderTarget = renderTarget;
-    }
-    RenderTarget*   getNextRenderTarget(){
-        return mNextRenderTarget;
-    }
+
     void            setMainScene(Scene* scene){mRenderState.scene = scene;}
     void            setCamera(Camera* cam) { mRenderState.camera= cam; }
     Camera*         getCamera() const { return mRenderState.camera; }
@@ -63,8 +57,8 @@ public:
     virtual void    beginRendering(Renderer* renderer);
     virtual void    endRendering(Renderer* renderer);
     static long long getComponentType() { return COMPONENT_TYPE_RENDER_TARGET; }
-    std::vector<RenderData*>* getRenderDataVector(){
-        return mRenderDataVector.get();
+    std::vector<RenderData*>* getRenderDataVector() {
+        return mRenderDataVector;
     }
     virtual void cullFromCamera(Scene*, jobject javaNode, Camera* camera, Renderer* renderer, ShaderManager* shader_manager);
 private:
@@ -74,10 +68,9 @@ private:
     RenderTarget& operator=(RenderTarget&& render_texture) = delete;
 
 protected:
-    RenderTarget*   mNextRenderTarget;
     RenderState     mRenderState;
     RenderTexture*  mRenderTexture = nullptr;
-    std::shared_ptr<std::vector<RenderData*>> mRenderDataVector;
+    std::vector<RenderData*> mRenderDataVector[Renderer::MAX_LAYERS];
 };
 
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/render_target_jni.cpp
@@ -39,8 +39,6 @@ extern "C" {
     Java_com_samsungxr_NativeRenderTarget_ctorViewport(JNIEnv *env, jobject obj, jlong jscene,
                                                      jint defaultViewportW, jint defaultViewportH);
     JNIEXPORT void JNICALL
-            Java_com_samsungxr_NativeRenderTarget_attachRenderTarget(JNIEnv *env, jobject obj, jlong jrendertarget, jlong jnextrendertarget);
-    JNIEXPORT void JNICALL
     Java_com_samsungxr_NativeRenderTarget_cullFromCamera(JNIEnv *env, jobject obj, jlong jscene, jobject javaNode, jlong ptr, jlong jcamera, jlong jshaderManager);
     JNIEXPORT void JNICALL
     Java_com_samsungxr_NativeRenderTarget_render(JNIEnv *env, jobject obj, jlong renderTarget, jlong camera,
@@ -59,7 +57,9 @@ Java_com_samsungxr_NativeRenderTarget_render(JNIEnv *env, jobject obj, jlong ren
     target->setCamera(reinterpret_cast<Camera*>(camera));
     javaNode = env->NewLocalRef(javaNode);
     gRenderer->getInstance()->renderRenderTarget(scene, javaNode, target, reinterpret_cast<ShaderManager*>(shader_manager),
-                                                 reinterpret_cast<RenderTexture*>(posteffectrenderTextureA), reinterpret_cast<RenderTexture*>(posteffectRenderTextureB));
+                                                 reinterpret_cast<RenderTexture*>(posteffectrenderTextureA),
+                                                 reinterpret_cast<RenderTexture*>(posteffectRenderTextureB),
+                                                 target->getRenderDataVector());
     env->DeleteLocalRef(javaNode);
 }
 
@@ -97,13 +97,6 @@ Java_com_samsungxr_NativeRenderTarget_setMainScene(JNIEnv *env, jobject obj, jlo
     RenderTarget* target = reinterpret_cast<RenderTarget*>(ptr);
     Scene* scene = reinterpret_cast<Scene*>(Sceneptr);
     target->setMainScene(scene);
-}
-
-JNIEXPORT void JNICALL
-Java_com_samsungxr_NativeRenderTarget_attachRenderTarget(JNIEnv *env, jobject obj, jlong jrendertarget, jlong jnextrendertarget){
-    RenderTarget* target = reinterpret_cast<RenderTarget*>(jrendertarget);
-    RenderTarget* nextrendertarget = reinterpret_cast<RenderTarget*>(jnextrendertarget);
-    target->attachNextRenderTarget(nextrendertarget);
 }
 
 JNIEXPORT void JNICALL

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/light.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/light.cpp
@@ -82,7 +82,7 @@ namespace sxr
         shadowMap->setMainScene(scene);
         shadowMap->cullFromCamera(scene, javaNode, shadowMap->getCamera(),renderer, shader_manager);
 
-        renderer->renderRenderTarget(scene, javaNode, shadowMap,shader_manager, nullptr, nullptr);
+        renderer->renderRenderTarget(scene, javaNode, shadowMap,shader_manager, nullptr, nullptr, shadowMap->getRenderDataVector());
 
         return true;
     }

--- a/SXR/SDK/sxrsdk/src/main/jni/view_manager_jni.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/view_manager_jni.cpp
@@ -58,7 +58,7 @@ extern "C" {
         javaNode = jni->NewLocalRef(javaNode);
         renderTarget->cullFromCamera(scene, javaNode, renderTarget->getCamera(),gRenderer,shader_manager);
 
-        gRenderer->renderRenderTarget(scene, javaNode, renderTarget,shader_manager,post_effect_render_texture_a,post_effect_render_texture_b);
+        gRenderer->renderRenderTarget(scene, javaNode, renderTarget,shader_manager,post_effect_render_texture_a,post_effect_render_texture_b, renderTarget->getRenderDataVector());
 
         //unbind the fbo on which the drawing was done
         if(renderTarget->getTexture())


### PR DESCRIPTION
Oculus adapter support added; Demos PR: https://github.com/sxrsdk/sxrsdk-demos/pull/77

1. Enable cursor layer support first by setting useCursorLayer=true in sxr.xml like that:
```
    <vr-app-settings
        ...
        useCursorLayer="true">
        ...
```
If useCursorLayer is false then no extra buffers will be allocated. If a scene object is assigned to the cursor layer it will be put back into the normal rendering bucket.

2. Switch to the newer vrapi_SubmitFrame2 Oculus Mobile SDK api for submitting buffers.

3. Use the global gUseMultiview flag to avoid passing it around from place to place. It is already there, why not use it.

4. Add layer value to RenderData. WorldLocked is what we already have and the default; HeadLocked is for objects attached to the camera rig.

5. Various little changes to the Renderer so it can operate on the two layers.

Known issues not planning to address as part of this PR:
The cursor layer is ignored if Vulkan is used.
Screenshots (except for left camera) do not work when multiview is enabled.

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>