### PR TITLE
Add alpha blend support to widgets, make them not cast shadows

### DIFF
--- a/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/RenderDataCache.java
+++ b/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/RenderDataCache.java
@@ -98,6 +98,13 @@ class RenderDataCache {
         }
     }
 
+    void setAlphaBlend(boolean flag) {
+        if (mRenderData != null) {
+            SET_ALPHA_BLEND.buffer(mExternalRenderData, flag);
+            mRenderData.setAlphaBlend(flag);
+        }
+    }
+
     void setRenderingOrder(int renderingOrder) {
         if (mRenderData != null) {
             SET_RENDERING_ORDER.buffer(mExternalRenderData, renderingOrder);
@@ -264,6 +271,21 @@ class RenderDataCache {
                 final SXRRenderData renderData = (SXRRenderData) params[0];
                 final boolean depthTest = (boolean) params[1];
                 renderData.setDepthTest(depthTest);
+            }
+        };
+    }
+
+    private static final class SET_ALPHA_BLEND {
+        static void buffer(SXRRenderData renderData, boolean alphaBlend) {
+            CommandBuffer.Command.buffer(sExecutor, renderData, alphaBlend);
+        }
+
+        private static final Command.Executor sExecutor = new Command.Executor() {
+            @Override
+            public void exec(Object... params) {
+                final SXRRenderData renderData = (SXRRenderData) params[0];
+                final boolean alphaBlend = (boolean) params[1];
+                renderData.setAlphaBlend(alphaBlend);
             }
         };
     }

--- a/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/RenderDataCache.java
+++ b/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/RenderDataCache.java
@@ -21,6 +21,7 @@ class RenderDataCache {
         mExternalRenderData = sceneObject.getRenderData();
         if (mExternalRenderData != null) {
             mRenderData = new SXRRenderData(sceneObject.getSXRContext());
+            mRenderData.setCastShadows(false);
             mRenderData.setDepthTest(mExternalRenderData.getDepthTest());
             mRenderData.setMesh(mExternalRenderData.getMesh());
             mRenderData.setOffset(mExternalRenderData.getOffset());

--- a/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/Widget.java
+++ b/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/Widget.java
@@ -864,6 +864,10 @@ public class Widget implements Layout.WidgetContainer {
         mRenderDataCache.setRenderingOrder(renderingOrder);
     }
 
+    public void setAlphaBlend(final boolean alphaBlend) {
+        mRenderDataCache.setAlphaBlend(alphaBlend);
+    }
+
     /**
      * @return The order in which this {@link Widget} will be rendered.
      * @see SXRRenderingOrder

--- a/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/Widget.java
+++ b/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/Widget.java
@@ -881,6 +881,7 @@ public class Widget implements Layout.WidgetContainer {
         mRenderDataCache.setCullFace(cullFace);
     }
 
+
     /**
      * Enable clipping for the Widget. Widget content including its children will be clipped by a
      * rectangular View Port. By default clipping is disabled.
@@ -3754,6 +3755,7 @@ public class Widget implements Layout.WidgetContainer {
                     SXRShaderType.Texture.ID);
             material.setMainTexture(sDefaultTexture);
             renderData.setMaterial(material);
+            renderData.setCastShadows(false);
         }
     }
 

--- a/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/basic/TextWidget.java
+++ b/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/basic/TextWidget.java
@@ -242,6 +242,7 @@ public class TextWidget extends Widget implements TextContainer {
         String text = optString(properties, TextContainer.Properties.text);
         SXRTextViewNode textViewNode =
                 new SXRTextViewNode(context, size.x, size.y, text);
+        textViewNode.getRenderData().setCastShadows(false);
         put(properties, Widget.Properties.node, textViewNode);
         return properties;
     }
@@ -254,6 +255,7 @@ public class TextWidget extends Widget implements TextContainer {
                     .calculateGeometricDimensions(sceneObject);
             final SXRNode temp = new SXRTextViewNode(
                     sceneObject.getSXRContext(), sizes[0], sizes[1], "");
+            temp.getRenderData().setCastShadows(false);
             sceneObject.addChildObject(temp);
             return (SXRTextViewNode) temp;
         }

--- a/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
+++ b/SXR/SDK/sxrsdk/src/main/java/com/samsungxr/animation/SXRAvatar.java
@@ -434,6 +434,7 @@ public class SXRAvatar implements IEventReceiver, SXRAnimationQueue.IAnimationQu
         else
         {
             modelInfo = mAttachments.get("avatar");
+            mSkeleton = null;
         }
         modelInfo.setModelRoot(modelRoot);
         modelInfo.parseModelDescription(modelDesc);
@@ -791,6 +792,11 @@ public class SXRAvatar implements IEventReceiver, SXRAnimationQueue.IAnimationQu
         if (a.getProperty("name") != null)
         {
             mAvatarRoot.setName(a.getProperty("name"));
+        }
+        while (mAvatarRoot.getChildrenCount() > 0)
+        {
+            SXRNode child = mAvatarRoot.getChildByIndex(0);
+            mAvatarRoot.removeChildObject(child);
         }
         mSkeleton = skel;
         mSkeleton.poseFromBones();


### PR DESCRIPTION
Most of the other SXRRenderData functions are there, this one is missing.

SXR DCO signed off by: Nola Donato nola.donato@samsung.com