### PR TITLE
mixed reality: daydream's camera is not perspective …

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCoreSession.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/arcore/ARCoreSession.java
@@ -41,6 +41,7 @@ import com.google.ar.core.exceptions.UnavailableArcoreNotInstalledException;
 import com.google.ar.core.exceptions.UnavailableSdkTooOldException;
 import com.google.ar.core.exceptions.UnavailableUserDeclinedInstallationException;
 
+import com.samsungxr.SXRCamera;
 import com.samsungxr.SXRCameraRig;
 import com.samsungxr.SXRContext;
 import com.samsungxr.SXRDrawFrameListener;
@@ -753,8 +754,16 @@ public class ARCoreSession implements IMixedReality
     private static void setVRCameraFov(SXRCameraRig camRig, float degreesFov)
     {
         camRig.getCenterCamera().setFovY(degreesFov);
-        ((SXRPerspectiveCamera)camRig.getLeftCamera()).setFovY(degreesFov);
-        ((SXRPerspectiveCamera)camRig.getRightCamera()).setFovY(degreesFov);
+
+        final SXRCamera leftCamera = camRig.getLeftCamera();
+        if (leftCamera instanceof SXRPerspectiveCamera) {
+            ((SXRPerspectiveCamera)leftCamera).setFovY(degreesFov);
+        }
+
+        final SXRCamera rightCamera = camRig.getRightCamera();
+        if (rightCamera instanceof SXRPerspectiveCamera) {
+            ((SXRPerspectiveCamera)rightCamera).setFovY(degreesFov);
+        }
     }
 
     @Override

--- a/SXR/SDK/sxrsdk/src/main/jni/gl/gl_vertex_buffer.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/gl/gl_vertex_buffer.cpp
@@ -8,7 +8,7 @@
 #include "gl_index_buffer.h"
 #include "gl_shader.h"
 
-//#define VERBOSE_LOGGING 0
+#define VERBOSE_LOGGING 0
 #include "util/sxr_log.h"
 
 namespace sxr {


### PR DESCRIPTION
… - ignore ar camera's fov for it.

vertex buffer: stop log spamming every frame

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>