### PR TITLE
fix for Quest

### DIFF
--- a/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrActivityDelegate.java
+++ b/SXR/SDK/backend_oculus/src/main/java/com/samsungxr/OvrActivityDelegate.java
@@ -107,8 +107,6 @@ final class OvrActivityDelegate extends SXRApplication.ActivityDelegateStubs {
     public VrAppSettings makeVrAppSettings() {
         final VrAppSettings settings = new OvrVrAppSettings();
         final VrAppSettings.EyeBufferParams params = settings.getEyeBufferParams();
-        params.setResolutionHeight(VrAppSettings.DEFAULT_FBO_RESOLUTION);
-        params.setResolutionWidth(VrAppSettings.DEFAULT_FBO_RESOLUTION);
         return settings;
     }
 


### PR DESCRIPTION
    remove explicitly setting the default framebuffer width and height and
    allow it to be queried from the Oculus SDK.
    
    the code in ovr_configuration_helper.cpp checks to see if the width or
    height are -1 (which is what they are initialized to) and if so, uses
    the value provided by the Oculus SDK.  By setting the width and height
    in OvrActivityDelegate.java, that check is bypassed.
    
    this appears to be one reason why apps on Quest look so funky right now.
    Eyebuffer on Quest are rectangular, not square.  The other appears to be related to needing 
    an asymmetric view frustum.  I'm still working on that issue.

SXR-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com
