### PR TITLE
asymmetric projection support for Quest

### DIFF
--- a/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
+++ b/SXR/SDK/backend_oculus/src/main/jni/ovr_activity.h
@@ -65,7 +65,7 @@ class RenderTarget;
         FrameBufferObject frameBuffer_[VRAPI_FRAME_LAYER_EYE_MAX];
         FrameBufferObject cursorBuffer_[VRAPI_FRAME_LAYER_EYE_MAX];
         ovrMatrix4f projectionMatrix_;
-        ovrMatrix4f texCoordsTanAnglesMatrix_;
+        ovrMatrix4f texCoordsTanAnglesMatrix_[2];
         ovrPerformanceParms oculusPerformanceParms_;
 
         bool mResolveDepthConfiguration = false;

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/camera.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/camera.h
@@ -82,6 +82,7 @@ public:
 
     void setPostEffect(RenderData* post_effects);
     virtual glm::mat4 getProjectionMatrix() const = 0;
+    virtual void setProjectionMatrix(const glm::mat4& matrix) = 0;
     virtual const glm::mat4& getViewMatrix();
     virtual void setViewMatrix(const glm::mat4& viewMtx);
     static long long getComponentType() {

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/custom_camera.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/custom_camera.h
@@ -45,6 +45,11 @@ public:
         return projection_matrix_;
     }
 
+    void setProjectionMatrix(const glm::mat4& projection_matrix) {
+        projection_matrix_ = projection_matrix;
+    }
+
+
 private:
     CustomCamera(const CustomCamera& camera) = delete;
     CustomCamera(CustomCamera&& camera) = delete;

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/orthogonal_camera.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/orthogonal_camera.cpp
@@ -25,8 +25,19 @@
 namespace sxr {
 
 glm::mat4 OrthogonalCamera::getProjectionMatrix() const {
+    if(is_custom) {
+        return projection_matrix_;
+    }
+
     return glm::ortho(left_clipping_distance_, right_clipping_distance_,
             bottom_clipping_distance_, top_clipping_distance_,
             near_clipping_distance_, far_clipping_distance_);
 }
+
+void OrthogonalCamera::setProjectionMatrix(const glm::mat4& matrix) {
+        projection_matrix_ = matrix;
+        is_custom = true;
+}
+
+
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/orthogonal_camera.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/orthogonal_camera.h
@@ -31,7 +31,7 @@ public:
             Camera(), left_clipping_distance_(-1.0f), right_clipping_distance_(
                     1.0f), bottom_clipping_distance_(-1.0f), top_clipping_distance_(
                     1.0f), near_clipping_distance_(0.0f), far_clipping_distance_(
-                    1.0f) {
+                    1.0f), is_custom(false) {
     }
 
     virtual ~OrthogonalCamera() {
@@ -86,6 +86,7 @@ public:
     }
 
     glm::mat4 getProjectionMatrix() const;
+    void setProjectionMatrix(const glm::mat4& matrix);
 
 private:
     OrthogonalCamera(const OrthogonalCamera& camera) = delete;
@@ -100,6 +101,8 @@ private:
     float top_clipping_distance_;
     float near_clipping_distance_;
     float far_clipping_distance_;
+    glm::mat4 projection_matrix_;
+    bool is_custom;
 };
 }
 #endif

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/perspective_camera.cpp
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/perspective_camera.cpp
@@ -27,7 +27,17 @@ float PerspectiveCamera::default_fov_y_ = glm::radians(95.0f);
 float PerspectiveCamera::default_aspect_ratio_ = 1.0f;
 
 glm::mat4 PerspectiveCamera::getProjectionMatrix() const {
+    if(is_custom) {
+        return projection_matrix_;
+    }
+
     return glm::perspective(fov_y_, aspect_ratio(), near_clipping_distance(),
             far_clipping_distance());
 }
+
+void PerspectiveCamera::setProjectionMatrix(const glm::mat4& matrix) {
+        projection_matrix_ = matrix;
+        is_custom = true;
+}
+
 }

--- a/SXR/SDK/sxrsdk/src/main/jni/objects/components/perspective_camera.h
+++ b/SXR/SDK/sxrsdk/src/main/jni/objects/components/perspective_camera.h
@@ -30,7 +30,7 @@ public:
     PerspectiveCamera() :
             Camera(), near_clipping_distance_(0.1f), far_clipping_distance_(
                     1000.0f), fov_y_(default_fov_y_), aspect_ratio_(
-                    default_aspect_ratio_) {
+                    default_aspect_ratio_), is_custom(false) {
     }
 
     virtual ~PerspectiveCamera() {
@@ -89,6 +89,7 @@ public:
     }
 
     glm::mat4 getProjectionMatrix() const;
+    void setProjectionMatrix(const glm::mat4& matrix);
 
 private:
     PerspectiveCamera(const PerspectiveCamera& camera) = delete;
@@ -103,6 +104,8 @@ private:
     float far_clipping_distance_;
     float fov_y_; // in radians
     float aspect_ratio_;
+    bool is_custom;
+    glm::mat4 projection_matrix_;
 };
 }
 #endif


### PR DESCRIPTION
add asymmetric projection support for Quest.

I think this fixes most (all?) of the visual issues with Quest at this point.  Still needs to be tested against GearVR.  Next I'll need to verify the controllers.

SXR-DCO-1.0-Signed-off-by: Tom Flynn
tom.flynn@samsung.com