### PR TITLE
build fix for MixedReality extension

### DIFF
--- a/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibrarySession.java
+++ b/SXR/Extensions/MixedReality/src/main/java/com/samsungxr/mixedreality/CVLibrary/CVLibrarySession.java
@@ -143,12 +143,6 @@ public class CVLibrarySession implements IMixedReality, SXRDrawFrameListener
 
     public void resume()
     {
-        mContext.registerDrawFrameListener(this);
-        mIsRunning = true;
-    }
-
-    public void resume()
-    {
         if (!mIsRunning)
         {
             mContext.getEventManager().sendEvent(this,


### PR DESCRIPTION
there were two resume() methods.  probably due to a merge mishap.

SXR-DCO-Signed-off-by: Tom Flynn
tom.flynn@samsung.com