### PR TITLE
support scrolling in AR. In the AR environment, there is a ARPassThro…

### DIFF
--- a/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/content_scene/ScrollableContentScene.java
+++ b/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/content_scene/ScrollableContentScene.java
@@ -14,6 +14,7 @@ import com.samsungxr.widgetlib.widget.FlingHandler;
  */
 abstract public class ScrollableContentScene implements ContentSceneController.ContentScene {
     private String TAG = tag(ScrollableContentScene.class);
+    private final int SCROLL_THRESHOLD = 50;
     private FlingHandler mFlingHandler = new FlingHandler() {
         private float startX;
         private float endX;
@@ -58,9 +59,13 @@ abstract public class ScrollableContentScene implements ContentSceneController.C
             endX = startX = 0;
 
             if (endY - startY > 0) {
-                scrollUp();
+                if(endY - startY > SCROLL_THRESHOLD) {
+                    scrollUp();
+                }
             } else {
-                scrollDown();
+                if(startY - endY > SCROLL_THRESHOLD) {
+                    scrollDown();
+                }
             }
             endY = startY = 0;
         }

--- a/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/Widget.java
+++ b/SXR/Extensions/widgetLib/src/com/samsungxr/widgetlib/widget/Widget.java
@@ -588,9 +588,18 @@ public class Widget implements Layout.WidgetContainer {
         }
     }
 
+
+    public void setScrollable(boolean enabled) {
+        mScrollable = enabled;
+    }
+    public boolean isScrollable() {
+        return mScrollable;
+    }
+
     /**
      * @return Whether touch and back key events are enabled for this object.
      */
+
     public boolean isTouchable() {
         return mIsTouchable;
     }
@@ -3852,6 +3861,8 @@ public class Widget implements Layout.WidgetContainer {
     private boolean mFocusEnabled = true;
     private boolean mChildrenFollowFocus = false;
     private boolean mFollowParentFocus = false;
+    private boolean mScrollable = false;
+
     private HandlesEvent mHandlesFocusEvent = new HandlesEvent() {
 
         @Override


### PR DESCRIPTION
…ugh sceneobject placed

behind everything else. Current scrolling detection in widgetPickHandler won't work. Therefore,
we have to patch a workaround to handle scrolling this scenario.

Signed-off-by: Yufi Li <tai-yun.li@samsung.com>